### PR TITLE
fix(bridge): sanitize control characters in JSON from DLL

### DIFF
--- a/bridge-service/src/services/dll-connector.ts
+++ b/bridge-service/src/services/dll-connector.ts
@@ -153,7 +153,14 @@ export class DLLConnector extends EventEmitter {
             try {
               const trimmed = item.trim();
               if (trimmed == "") return;
-              const jsonData = JSON.parse(trimmed);
+              // Sanitize control characters that may not be properly escaped by the DLL
+              // This escapes all control chars (0x00-0x1F) as Unicode escape sequences
+              const sanitized = trimmed.replace(/[\x00-\x1f]/g, (char) => {
+                // Allow \t, \n, \r if they're already escaped (preceded by backslash)
+                // But since we're replacing raw chars, we escape them all
+                return '\\u' + ('0000' + char.charCodeAt(0).toString(16)).slice(-4);
+              });
+              const jsonData = JSON.parse(sanitized);
               this.handleMessage(jsonData);
             } catch (error) {
               logger.error('Failed to process JSON data:', error);


### PR DESCRIPTION
## Summary

  - Added control character sanitization in `dll-connector.ts` before JSON parsing
  - Escapes all control characters (0x00-0x1F) as Unicode escape sequences (`\u00XX`)
  - Fixes "Bad control character in string literal" JSON parsing errors

  ## Problem

  The DLL sometimes sends JSON with unescaped control characters in string literals (likely from game text data containing newlines, tabs, or other control characters). This causes `JSON.parse()` to fail with:

  SyntaxError: Bad control character in string literal in JSON at position 932

  ## Solution

  Added a sanitization step before parsing that escapes all control characters.

  ## Test plan

  - [x] Tested with live game session - 0 JSON parsing errors after fix
  - [x] Game progressed from turn 37 to 73+ without issues
  - [x] All MCP tool calls working correctly
