### PR TITLE
feat(civ5-mod): Add PopupBroadcaster for UI popup visibility

### DIFF
--- a/civ5-mod/UI/PopupBroadcaster.lua
+++ b/civ5-mod/UI/PopupBroadcaster.lua
@@ -1,0 +1,118 @@
+-------------------------------------------------
+-- Popup Broadcaster for Vox Deorum
+--
+-- Captures all popup events and writes them to
+-- MapModData for the bridge to read.
+-------------------------------------------------
+
+-- Initialize our namespace in MapModData
+if not MapModData.VoxDeorum then
+    MapModData.VoxDeorum = {}
+end
+
+-- Track popup history for debugging
+MapModData.VoxDeorum.PopupHistory = MapModData.VoxDeorum.PopupHistory or {}
+
+-------------------------------------------------
+-- Popup Type Names (for human-readable output)
+-------------------------------------------------
+local PopupTypeNames = {
+    [ButtonPopupTypes.BUTTONPOPUP_TEXT] = "TEXT",
+    [ButtonPopupTypes.BUTTONPOPUP_CONFIRM_MENU] = "CONFIRM_MENU",
+    [ButtonPopupTypes.BUTTONPOPUP_DECLAREWARMOVE] = "DECLARE_WAR_MOVE",
+    [ButtonPopupTypes.BUTTONPOPUP_DECLAREWAR] = "DECLARE_WAR",
+    [ButtonPopupTypes.BUTTONPOPUP_DECLAREWAR_PLUNDER_TRADE_ROUTE] = "DECLARE_WAR_PLUNDER",
+    [ButtonPopupTypes.BUTTONPOPUP_CONFIRMCOMMAND] = "CONFIRM_COMMAND",
+    [ButtonPopupTypes.BUTTONPOPUP_CONFIRMMISSION] = "CONFIRM_MISSION",
+    [ButtonPopupTypes.BUTTONPOPUP_CHOOSETECH] = "CHOOSE_TECH",
+    [ButtonPopupTypes.BUTTONPOPUP_CHOOSEPRODUCTION] = "CHOOSE_PRODUCTION",
+    [ButtonPopupTypes.BUTTONPOPUP_CHOOSEPOLICY] = "CHOOSE_POLICY",
+    [ButtonPopupTypes.BUTTONPOPUP_CHOOSEELECTION] = "CHOOSE_ELECTION",
+    [ButtonPopupTypes.BUTTONPOPUP_CHOOSEGOODY] = "CHOOSE_GOODY",
+    [ButtonPopupTypes.BUTTONPOPUP_CITY_CAPTURED] = "CITY_CAPTURED",
+    [ButtonPopupTypes.BUTTONPOPUP_ANNEX_CITY] = "ANNEX_CITY",
+    [ButtonPopupTypes.BUTTONPOPUP_CHOOSE_PANTHEON] = "CHOOSE_PANTHEON",
+    [ButtonPopupTypes.BUTTONPOPUP_CHOOSE_RELIGION] = "CHOOSE_RELIGION",
+    [ButtonPopupTypes.BUTTONPOPUP_CHOOSE_IDEOLOGY] = "CHOOSE_IDEOLOGY",
+    [ButtonPopupTypes.BUTTONPOPUP_GOLDEN_AGE_REWARD] = "GOLDEN_AGE_REWARD",
+    [ButtonPopupTypes.BUTTONPOPUP_GREAT_PERSON_REWARD] = "GREAT_PERSON_REWARD",
+    [ButtonPopupTypes.BUTTONPOPUP_CHOOSE_ADMIRAL_PORT] = "CHOOSE_ADMIRAL_PORT",
+    [ButtonPopupTypes.BUTTONPOPUP_BARBARIAN_CAMP_REWARD] = "BARBARIAN_CAMP_REWARD",
+    [ButtonPopupTypes.BUTTONPOPUP_LEAGUE_OVERVIEW] = "LEAGUE_OVERVIEW",
+    [ButtonPopupTypes.BUTTONPOPUP_CHOOSE_ARCHAEOLOGY] = "CHOOSE_ARCHAEOLOGY",
+    [ButtonPopupTypes.BUTTONPOPUP_GIFT_CONFIRM] = "GIFT_CONFIRM",
+    [ButtonPopupTypes.BUTTONPOPUP_KICKED] = "KICKED",
+    [ButtonPopupTypes.BUTTONPOPUP_RELIGION_OVERVIEW] = "RELIGION_OVERVIEW",
+    [ButtonPopupTypes.BUTTONPOPUP_ECONOMIC_OVERVIEW] = "ECONOMIC_OVERVIEW",
+    [ButtonPopupTypes.BUTTONPOPUP_MILITARY_OVERVIEW] = "MILITARY_OVERVIEW",
+    [ButtonPopupTypes.BUTTONPOPUP_DEMOGRAPHICS] = "DEMOGRAPHICS",
+}
+
+-- Get human-readable popup type name
+local function GetPopupTypeName(popupType)
+    return PopupTypeNames[popupType] or ("UNKNOWN_" .. tostring(popupType))
+end
+
+-------------------------------------------------
+-- Capture ALL popup events
+-------------------------------------------------
+function OnPopupOpened(popupInfo)
+    if popupInfo == nil then return end
+
+    local popupData = {
+        Type = popupInfo.Type,
+        TypeName = GetPopupTypeName(popupInfo.Type),
+        Data1 = popupInfo.Data1,
+        Data2 = popupInfo.Data2,
+        Data3 = popupInfo.Data3,
+        Text = popupInfo.Text,
+        Option1 = popupInfo.Option1,
+        Option2 = popupInfo.Option2,
+        Timestamp = os.time(),
+        Turn = Game.GetGameTurn(),
+    }
+
+    -- Store as active popup
+    MapModData.VoxDeorum.ActivePopup = popupData
+
+    -- Add to history (keep last 10)
+    table.insert(MapModData.VoxDeorum.PopupHistory, 1, popupData)
+    while #MapModData.VoxDeorum.PopupHistory > 10 do
+        table.remove(MapModData.VoxDeorum.PopupHistory)
+    end
+
+    print("[VoxDeorum] Popup opened: " .. popupData.TypeName)
+end
+Events.SerialEventGameMessagePopup.Add(OnPopupOpened)
+
+-------------------------------------------------
+-- Track when popups are processed/closed
+-------------------------------------------------
+function OnPopupProcessed(popupType, popupData)
+    -- Clear active popup if it matches
+    if MapModData.VoxDeorum.ActivePopup and
+       MapModData.VoxDeorum.ActivePopup.Type == popupType then
+        print("[VoxDeorum] Popup closed: " .. GetPopupTypeName(popupType))
+        MapModData.VoxDeorum.ActivePopup = nil
+    end
+end
+Events.SerialEventGameMessagePopupProcessed.Add(OnPopupProcessed)
+
+-------------------------------------------------
+-- Track popup shown events (for popups that use this)
+-------------------------------------------------
+function OnPopupShown(popupInfo)
+    if popupInfo == nil then return end
+    -- Update timestamp when actually shown (some popups queue before showing)
+    if MapModData.VoxDeorum.ActivePopup and
+       MapModData.VoxDeorum.ActivePopup.Type == popupInfo.Type then
+        MapModData.VoxDeorum.ActivePopup.ShownTimestamp = os.time()
+    end
+end
+Events.SerialEventGameMessagePopupShown.Add(OnPopupShown)
+
+-------------------------------------------------
+-- Initialize on load
+-------------------------------------------------
+print("[VoxDeorum] PopupBroadcaster loaded - monitoring all popup events")
+MapModData.VoxDeorum.PopupBroadcasterActive = true

--- a/civ5-mod/VoxDeorum.modinfo
+++ b/civ5-mod/VoxDeorum.modinfo
@@ -29,6 +29,7 @@
     <File md5="3847BD8F67C81B24B13D5DB36F8F737B" import="0">Text/VoxDeorum_Text.xml</File>
     <File md5="C3A72CC7D49D2E54948ABFCFA473E519" import="0">Text/VoxDeorum_Text.sql</File>
     <File md5="3A42737A457702DFE8A466F6C000BC18" import="1">Mapscripts/Vox_Deorum.lua</File>
+    <File md5="00000000000000000000000000000000" import="0">UI/PopupBroadcaster.lua</File>
   </Files>
   <Actions>
     <OnModActivated>
@@ -41,6 +42,10 @@
     <EntryPoint type="MapScript" file="Mapscripts/Vox_Deorum.lua">
       <Name>Vox_Deorum</Name>
       <Description>Communitas rewrite by tu_79 and azum4roll - fixed parameters for Vox Deorum research</Description>
+    </EntryPoint>
+    <EntryPoint type="InGameUIAddin" file="UI/PopupBroadcaster.lua">
+      <Name>PopupBroadcaster</Name>
+      <Description>Broadcasts popup events to MapModData for bridge visibility</Description>
     </EntryPoint>
   </EntryPoints>
 </Mod>

--- a/mcp-server/lua/get-combat-preview.lua
+++ b/mcp-server/lua/get-combat-preview.lua
@@ -1,0 +1,280 @@
+-- Get combat preview for AI accessibility
+-- Returns combat predictions for attacker vs potential targets
+-- Addresses combat prediction gap identified in Issue #469
+
+-- Input parameters:
+-- playerID: Player perspective
+-- attackerUnitID: (optional) Specific attacker unit ID
+-- defenderUnitID: (optional) Specific defender unit ID
+-- showAllTargets: (optional) If true, show all valid targets for the attacker
+
+local results = {}
+local pPlayer = Players[playerID]
+
+if not pPlayer then
+  return results
+end
+
+local ourTeam = pPlayer:GetTeam()
+
+-- Helper: Get unit owner name
+local function getOwnerName(unit)
+  local ownerID = unit:GetOwner()
+  local owner = Players[ownerID]
+  if not owner then return "Unknown" end
+
+  if owner:IsMinorCiv() then
+    return "City-State " .. owner:GetName()
+  elseif owner:IsBarbarian() then
+    return "Barbarians"
+  else
+    return owner:GetCivilizationShortDescription()
+  end
+end
+
+-- Helper: Get unit info
+local function getUnitInfo(unit)
+  local unitInfo = GameInfo.Units[unit:GetUnitType()]
+  local name = unitInfo and Locale.ConvertTextKey(unitInfo.Description) or "Unknown"
+
+  return {
+    ID = unit:GetID(),
+    Name = name,
+    Owner = getOwnerName(unit),
+    X = unit:GetX(),
+    Y = unit:GetY(),
+    CurrentHP = unit:GetCurrHitPoints(),
+    MaxHP = unit:GetMaxHitPoints(),
+    BaseStrength = unit:GetBaseCombatStrength(),
+    RangedStrength = unit:GetBaseRangedCombatStrength(),
+    Moves = unit:GetMoves() / GameDefines.MOVE_DENOMINATOR,
+    MaxMoves = unit:MaxMoves() / GameDefines.MOVE_DENOMINATOR,
+  }
+end
+
+-- Helper: Convert combat prediction enum to string
+local function predictionToString(prediction)
+  -- CombatPredictionTypes enum values
+  local predictions = {
+    [0] = "Ranged",       -- No counter damage
+    [1] = "Stalemate",
+    [2] = "TotalDefeat",
+    [3] = "TotalVictory",
+    [4] = "MajorVictory",
+    [5] = "SmallVictory",
+    [6] = "MajorDefeat",
+    [7] = "SmallDefeat",
+  }
+  return predictions[prediction] or "Unknown"
+end
+
+-- Helper: Assess risk level
+local function assessRisk(prediction, attackerWouldDie, defenderWouldDie)
+  if attackerWouldDie then
+    return "Suicidal"
+  elseif prediction == 2 or prediction == 6 then -- TotalDefeat or MajorDefeat
+    return "Dangerous"
+  elseif prediction == 7 or prediction == 1 then -- SmallDefeat or Stalemate
+    return "Risky"
+  elseif prediction == 5 then -- SmallVictory
+    return "Favorable"
+  else -- TotalVictory, MajorVictory, Ranged
+    return "Safe"
+  end
+end
+
+-- Helper: Get combat modifiers for a unit
+local function getModifiers(unit, isAttacker, plot, enemyUnit)
+  local modifiers = {}
+
+  -- Terrain modifiers
+  if not isAttacker and plot then
+    if plot:IsHills() then
+      table.insert(modifiers, { Source = "Hills", Value = 25 })
+    end
+    if plot:IsRiver() then
+      table.insert(modifiers, { Source = "River Defense", Value = 10 })
+    end
+    local featureType = plot:GetFeatureType()
+    if featureType >= 0 then
+      local featureInfo = GameInfo.Features[featureType]
+      if featureInfo and featureInfo.Defense and featureInfo.Defense > 0 then
+        table.insert(modifiers, { Source = Locale.ConvertTextKey(featureInfo.Description), Value = featureInfo.Defense })
+      end
+    end
+  end
+
+  -- Health penalty
+  local healthPercent = (unit:GetCurrHitPoints() / unit:GetMaxHitPoints()) * 100
+  if healthPercent < 100 then
+    local penalty = math.floor((100 - healthPercent) / 2)
+    if penalty > 0 then
+      table.insert(modifiers, { Source = "Damaged", Value = -penalty })
+    end
+  end
+
+  -- Flanking (simplified - check for adjacent friendly units)
+  if isAttacker and enemyUnit then
+    local enemyPlot = enemyUnit:GetPlot()
+    if enemyPlot then
+      local flankingBonus = 0
+      for direction = 0, 5 do
+        local adjPlot = Map.PlotDirection(enemyPlot:GetX(), enemyPlot:GetY(), direction)
+        if adjPlot then
+          local numUnits = adjPlot:GetNumUnits()
+          for i = 0, numUnits - 1 do
+            local adjUnit = adjPlot:GetUnit(i)
+            if adjUnit and adjUnit:GetOwner() == unit:GetOwner() and adjUnit:GetID() ~= unit:GetID() then
+              if adjUnit:GetBaseCombatStrength() > 0 then
+                flankingBonus = flankingBonus + 10
+              end
+            end
+          end
+        end
+      end
+      if flankingBonus > 0 then
+        table.insert(modifiers, { Source = "Flanking", Value = math.min(flankingBonus, 50) })
+      end
+    end
+  end
+
+  return modifiers
+end
+
+-- Helper: Calculate combat preview between two units
+local function getCombatPreview(attacker, defender)
+  -- Get basic prediction
+  local prediction = Game.GetCombatPrediction(attacker, defender)
+  local predictionStr = predictionToString(prediction)
+
+  -- Calculate damage
+  local attackerStrength = attacker:GetMaxAttackStrength(attacker:GetPlot(), defender:GetPlot(), defender)
+  local defenderStrength = defender:GetMaxDefenseStrength(defender:GetPlot(), attacker, attacker:GetPlot(), false)
+
+  local damageToDefender = 0
+  local damageToAttacker = 0
+
+  local isRanged = attacker:GetBaseRangedCombatStrength() > 0 and attacker:IsRangeAttackIgnoreLOS() == false
+
+  if isRanged then
+    -- Ranged attack - use ranged combat damage
+    damageToDefender = attacker:GetRangeCombatDamage(defender, nil, false)
+    damageToAttacker = 0 -- No counter-attack from ranged
+  else
+    -- Melee attack
+    damageToDefender = attacker:GetMeleeCombatDamage(attackerStrength, defenderStrength, false, defender, 0)
+    damageToAttacker = defender:GetMeleeCombatDamage(defenderStrength, attackerStrength, false, attacker, 0)
+  end
+
+  -- Would they die?
+  local defenderWouldDie = damageToDefender >= defender:GetCurrHitPoints()
+  local attackerWouldDie = damageToAttacker >= attacker:GetCurrHitPoints()
+
+  -- Get modifiers
+  local attackerModifiers = getModifiers(attacker, true, attacker:GetPlot(), defender)
+  local defenderModifiers = getModifiers(defender, false, defender:GetPlot(), attacker)
+
+  return {
+    Attacker = getUnitInfo(attacker),
+    Defender = {
+      ID = defender:GetID(),
+      Name = getUnitInfo(defender).Name,
+      Type = "Unit",
+      Owner = getOwnerName(defender),
+      X = defender:GetX(),
+      Y = defender:GetY(),
+      CurrentHP = defender:GetCurrHitPoints(),
+      MaxHP = defender:GetMaxHitPoints(),
+      BaseStrength = defender:GetBaseCombatStrength(),
+    },
+    Prediction = predictionStr,
+    ExpectedDamageToDefender = damageToDefender,
+    ExpectedDamageToAttacker = damageToAttacker,
+    DefenderWouldDie = defenderWouldDie,
+    AttackerWouldDie = attackerWouldDie,
+    RiskLevel = assessRisk(prediction, attackerWouldDie, defenderWouldDie),
+    IsRanged = isRanged,
+    CanCounterAttack = not isRanged and defender:GetBaseCombatStrength() > 0,
+    AttackerModifiers = attackerModifiers,
+    DefenderModifiers = defenderModifiers,
+  }
+end
+
+-- Helper: Get all valid attack targets for a unit
+local function getValidTargets(attacker)
+  local targets = {}
+  local attackerPlot = attacker:GetPlot()
+  if not attackerPlot then return targets end
+
+  local range = attacker:GetRange()
+  if range == 0 then range = 1 end -- Melee units
+
+  -- Check tiles in range
+  local attackerX = attacker:GetX()
+  local attackerY = attacker:GetY()
+
+  for dx = -range, range do
+    for dy = -range, range do
+      local distance = math.max(math.abs(dx), math.abs(dy), math.abs(dx + dy))
+      if distance <= range and distance > 0 then
+        local x = attackerX + dx
+        local y = attackerY + dy
+
+        local plot = Map.GetPlot(x, y)
+        if plot and plot:IsVisible(ourTeam, false) then
+          -- Check for enemy units
+          local numUnits = plot:GetNumUnits()
+          for i = 0, numUnits - 1 do
+            local unit = plot:GetUnit(i)
+            if unit and not unit:IsInvisible(ourTeam, false) then
+              local unitOwner = unit:GetOwner()
+              -- Is this an enemy?
+              if Teams[ourTeam]:IsAtWar(Players[unitOwner]:GetTeam()) then
+                table.insert(targets, unit)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+
+  return targets
+end
+
+-- Main logic
+if attackerUnitID then
+  -- Get specific attacker
+  local attacker = pPlayer:GetUnitByID(attackerUnitID)
+  if not attacker then
+    return results
+  end
+
+  if defenderUnitID then
+    -- Specific attacker vs specific defender
+    -- Find the defender unit (could belong to any player)
+    local defender = nil
+    for iPlayer = 0, GameDefines.MAX_PLAYERS - 1 do
+      local pLoopPlayer = Players[iPlayer]
+      if pLoopPlayer and pLoopPlayer:IsAlive() then
+        local unit = pLoopPlayer:GetUnitByID(defenderUnitID)
+        if unit then
+          defender = unit
+          break
+        end
+      end
+    end
+
+    if defender then
+      table.insert(results, getCombatPreview(attacker, defender))
+    end
+  elseif showAllTargets then
+    -- Get all valid targets for this attacker
+    local targets = getValidTargets(attacker)
+    for _, defender in ipairs(targets) do
+      table.insert(results, getCombatPreview(attacker, defender))
+    end
+  end
+end
+
+return results

--- a/mcp-server/lua/get-culture-influence.lua
+++ b/mcp-server/lua/get-culture-influence.lua
@@ -1,0 +1,169 @@
+-- Get culture/tourism influence for AI accessibility
+-- Returns influence levels, tourism, ideology
+-- Addresses culture gap identified in Issue #469
+
+local pPlayer = Players[playerID]
+if not pPlayer then
+  return nil
+end
+
+local result = {
+  -- Our culture output
+  OurCulturePerTurn = pPlayer:GetTotalJONSCulturePerTurn(),
+  OurTourismPerTurn = pPlayer:GetTourism(),
+
+  -- Our ideology
+  OurIdeology = nil,
+  IdeologyLevel = 0,
+
+  -- Influence on others
+  InfluenceOnOthers = {},
+
+  -- Others' influence on us
+  InfluenceOnUs = {},
+
+  -- Public opinion
+  PublicOpinion = "Content",
+  PublicOpinionUnhappiness = pPlayer:GetUnhappinessFromPublicOpinion(),
+  PreferredIdeology = nil,
+
+  -- Great works summary
+  GreatWorksCount = 0,
+  ThemedBonuses = 0,
+
+  -- Per-city culture
+  CultureByCity = {},
+}
+
+-- Get our ideology
+local ideologyBranch = pPlayer:GetLateGamePolicyTree()
+if ideologyBranch >= 0 then
+  local branchInfo = GameInfo.PolicyBranchTypes[ideologyBranch]
+  if branchInfo then
+    result.OurIdeology = Locale.ConvertTextKey(branchInfo.Description)
+    -- Count tenets adopted
+    for policy in GameInfo.Policies() do
+      if policy.PolicyBranchType == branchInfo.Type and pPlayer:HasPolicy(policy.ID) then
+        result.IdeologyLevel = result.IdeologyLevel + 1
+      end
+    end
+  end
+end
+
+-- Get public opinion details
+local publicOpinionType = pPlayer:GetPublicOpinionType()
+if publicOpinionType == 1 then
+  result.PublicOpinion = "Dissidents"
+elseif publicOpinionType == 2 then
+  result.PublicOpinion = "Civil Resistance"
+elseif publicOpinionType == 3 then
+  result.PublicOpinion = "Revolutionary Wave"
+end
+
+local preferredIdeology = pPlayer:GetPublicOpinionPreferredIdeology()
+if preferredIdeology >= 0 then
+  local branchInfo = GameInfo.PolicyBranchTypes[preferredIdeology]
+  if branchInfo then
+    result.PreferredIdeology = Locale.ConvertTextKey(branchInfo.Description)
+  end
+end
+
+-- Get influence on each other civ
+for iPlayer = 0, GameDefines.MAX_MAJOR_CIVS - 1 do
+  local pLoopPlayer = Players[iPlayer]
+  if pLoopPlayer and pLoopPlayer:IsAlive() and iPlayer ~= playerID then
+    -- Skip if we haven't met them
+    if pPlayer:GetTeam():IsHasMet(pLoopPlayer:GetTeam()) then
+      local influenceData = {
+        CivName = pLoopPlayer:GetCivilizationShortDescription(),
+        InfluencePercent = pPlayer:GetInfluenceOn(iPlayer),
+        TheirCulturePerTurn = pLoopPlayer:GetTotalJONSCulturePerTurn(),
+        TourismTowardThem = pPlayer:GetTourismPerTurnAgainst(iPlayer),
+      }
+
+      -- Determine influence level
+      local percent = influenceData.InfluencePercent
+      if percent < 10 then
+        influenceData.InfluenceLevel = "Unknown"
+      elseif percent < 30 then
+        influenceData.InfluenceLevel = "Exotic"
+      elseif percent < 60 then
+        influenceData.InfluenceLevel = "Familiar"
+      elseif percent < 100 then
+        influenceData.InfluenceLevel = "Popular"
+      elseif percent < 200 then
+        influenceData.InfluenceLevel = "Influential"
+      else
+        influenceData.InfluenceLevel = "Dominant"
+      end
+
+      -- Estimate turns to next level
+      if influenceData.TourismTowardThem > 0 and influenceData.TheirCulturePerTurn > 0 then
+        local netTourism = influenceData.TourismTowardThem - (influenceData.TheirCulturePerTurn * 0.1)
+        if netTourism > 0 then
+          -- Rough estimate
+          local nextThreshold = 0
+          if percent < 30 then nextThreshold = 30
+          elseif percent < 60 then nextThreshold = 60
+          elseif percent < 100 then nextThreshold = 100
+          elseif percent < 200 then nextThreshold = 200
+          end
+
+          if nextThreshold > percent then
+            local remaining = nextThreshold - percent
+            influenceData.TurnsToNextLevel = math.ceil(remaining / (netTourism / influenceData.TheirCulturePerTurn * 100))
+          end
+        end
+      end
+
+      table.insert(result.InfluenceOnOthers, influenceData)
+    end
+  end
+end
+
+-- Get others' influence on us
+for iPlayer = 0, GameDefines.MAX_MAJOR_CIVS - 1 do
+  local pLoopPlayer = Players[iPlayer]
+  if pLoopPlayer and pLoopPlayer:IsAlive() and iPlayer ~= playerID then
+    if pPlayer:GetTeam():IsHasMet(pLoopPlayer:GetTeam()) then
+      local percent = pLoopPlayer:GetInfluenceOn(playerID)
+      if percent > 0 then
+        local influenceData = {
+          CivName = pLoopPlayer:GetCivilizationShortDescription(),
+          InfluencePercent = percent,
+        }
+
+        if percent < 10 then
+          influenceData.InfluenceLevel = "Unknown"
+        elseif percent < 30 then
+          influenceData.InfluenceLevel = "Exotic"
+        elseif percent < 60 then
+          influenceData.InfluenceLevel = "Familiar"
+        elseif percent < 100 then
+          influenceData.InfluenceLevel = "Popular"
+        elseif percent < 200 then
+          influenceData.InfluenceLevel = "Influential"
+        else
+          influenceData.InfluenceLevel = "Dominant"
+        end
+
+        table.insert(result.InfluenceOnUs, influenceData)
+      end
+    end
+  end
+end
+
+-- Count great works
+for city in pPlayer:Cities() do
+  result.GreatWorksCount = result.GreatWorksCount + city:GetNumGreatWorks()
+
+  -- Per-city culture
+  table.insert(result.CultureByCity, {
+    Name = city:GetName(),
+    CulturePerTurn = city:GetJONSCulturePerTurn(),
+    TourismPerTurn = city:GetBaseTourism() / 100,
+    GreatWorks = city:GetNumGreatWorks(),
+  })
+end
+
+return result

--- a/mcp-server/lua/get-espionage.lua
+++ b/mcp-server/lua/get-espionage.lua
@@ -1,0 +1,134 @@
+-- Get espionage info for AI accessibility
+-- Returns spy locations, states, and intelligence
+-- Addresses espionage gap identified in Issue #469
+
+local pPlayer = Players[playerID]
+if not pPlayer then
+  return nil
+end
+
+local result = {
+  -- Our spies
+  Spies = {},
+
+  -- City intelligence
+  CityIntelligence = {},
+
+  -- Intrigue messages
+  IntrigueMessages = {},
+}
+
+-- Get our spies
+local spies = pPlayer:GetEspionageSpies()
+if spies then
+  for i, spy in ipairs(spies) do
+    local spyData = {
+      Name = spy.Name,
+      Rank = spy.Rank,
+    }
+
+    -- Location
+    if spy.CityX and spy.CityY then
+      local plot = Map.GetPlot(spy.CityX, spy.CityY)
+      if plot then
+        local city = plot:GetPlotCity()
+        if city then
+          spyData.Location = city:GetName()
+          spyData.LocationOwner = Players[city:GetOwner()] and
+                                  Players[city:GetOwner()]:GetCivilizationShortDescription() or "Unknown"
+        end
+      end
+    end
+
+    -- State
+    if spy.IsDiplomat then
+      spyData.State = "Diplomat"
+    elseif spy.EstablishedSurveillance then
+      spyData.State = "Surveillance"
+    elseif spy.State == 0 then
+      spyData.State = "Unassigned"
+    elseif spy.State == 1 then
+      spyData.State = "Travelling"
+    elseif spy.State == 2 then
+      spyData.State = "GatheringIntel"
+    elseif spy.State == 3 then
+      spyData.State = "RiggingElection"
+    elseif spy.State == 4 then
+      spyData.State = "CounterIntelligence"
+    elseif spy.State == 5 then
+      spyData.State = "StagingCoup"
+    elseif spy.State == 6 then
+      spyData.State = "Schmoozing"
+    else
+      spyData.State = "Unknown"
+    end
+
+    -- Progress for certain states
+    if spy.TurnsInState then
+      spyData.TurnsInState = spy.TurnsInState
+    end
+
+    table.insert(result.Spies, spyData)
+  end
+end
+
+-- Get city espionage potential for cities we know about
+for iPlayer = 0, GameDefines.MAX_MAJOR_CIVS - 1 do
+  local pLoopPlayer = Players[iPlayer]
+  if pLoopPlayer and pLoopPlayer:IsAlive() and iPlayer ~= playerID then
+    for city in pLoopPlayer:Cities() do
+      -- Check if we've revealed this city
+      local plot = city:Plot()
+      if plot and plot:IsRevealed(pPlayer:GetTeam(), false) then
+        local cityData = {
+          CityName = city:GetName(),
+          Owner = pLoopPlayer:GetCivilizationShortDescription(),
+          Population = city:GetPopulation(),
+        }
+
+        -- Check if we have a spy there
+        cityData.HasOurSpy = city:HasSpy(playerID)
+
+        -- Get potential (based on population, tech level, etc.)
+        -- Higher population = more potential
+        cityData.EspionagePotential = city:GetPopulation() * 10
+
+        -- Capital bonus
+        if city:IsCapital() then
+          cityData.EspionagePotential = cityData.EspionagePotential + 50
+          cityData.IsCapital = true
+        end
+
+        table.insert(result.CityIntelligence, cityData)
+      end
+    end
+  end
+end
+
+-- Get our own cities' counterintelligence
+for city in pPlayer:Cities() do
+  local cityData = {
+    CityName = city:GetName(),
+    Owner = "Us",
+    HasOurSpy = city:HasSpy(playerID),
+    IsOurCity = true,
+  }
+
+  table.insert(result.CityIntelligence, cityData)
+end
+
+-- Get intrigue messages (last 10)
+local intrigueCount = pPlayer:GetNumIntrigueMessages()
+local startIndex = math.max(0, intrigueCount - 10)
+for i = startIndex, intrigueCount - 1 do
+  local intrigue = pPlayer:GetIntrigueMessage(i)
+  if intrigue then
+    table.insert(result.IntrigueMessages, {
+      Turn = intrigue.Turn,
+      Message = intrigue.Message,
+      SpyName = intrigue.SpyName,
+    })
+  end
+end
+
+return result

--- a/mcp-server/lua/get-happiness.lua
+++ b/mcp-server/lua/get-happiness.lua
@@ -1,0 +1,122 @@
+-- Get happiness breakdown for AI accessibility
+-- Returns full happiness/unhappiness sources
+-- Addresses happiness gap identified in Issue #469
+
+local pPlayer = Players[playerID]
+if not pPlayer then
+  return nil
+end
+
+local result = {
+  -- Totals
+  TotalHappiness = pPlayer:GetHappiness(),
+  TotalUnhappiness = pPlayer:GetUnhappiness(),
+  NetHappiness = pPlayer:GetExcessHappiness(),
+
+  -- Happiness sources
+  HappinessSources = {
+    FromCities = pPlayer:GetHappinessFromCities(),
+    FromTradeRoutes = pPlayer:GetHappinessFromTradeRoutes(),
+    FromReligion = pPlayer:GetHappinessFromReligion(),
+    FromNaturalWonders = pPlayer:GetHappinessFromNaturalWonders(),
+    FromMinorCivs = pPlayer:GetHappinessFromMinorCivs(),
+    FromLeagues = pPlayer:GetHappinessFromLeagues(),
+    FromVassals = pPlayer:GetHappinessFromVassals(),
+    FromLuxuries = pPlayer:GetHappinessFromResources(),
+    FromPolicies = pPlayer:GetHappinessFromPolicies(),
+    FromBuildings = pPlayer:GetHappinessFromBuildings(),
+    FromExtraHappinessPerCity = pPlayer:GetExtraHappinessPerCity() * pPlayer:GetNumCities(),
+  },
+
+  -- Unhappiness sources
+  UnhappinessSources = {
+    FromCities = pPlayer:GetUnhappinessFromCityCount(),
+    FromPopulation = pPlayer:GetUnhappinessFromCityPopulation(),
+    FromOccupation = pPlayer:GetUnhappinessFromOccupiedCities(),
+    FromPublicOpinion = pPlayer:GetUnhappinessFromPublicOpinion(),
+    FromUnits = pPlayer:GetUnhappinessFromUnits(),
+    FromCitySpecialists = pPlayer:GetUnhappinessFromCitySpecialists(),
+    FromWarWeariness = pPlayer:GetUnhappinessFromWarWeariness(),
+  },
+
+  -- Golden Age info
+  IsGoldenAge = pPlayer:IsGoldenAge(),
+  GoldenAgeProgress = pPlayer:GetGoldenAgeProgressMeter(),
+  GoldenAgeThreshold = pPlayer:GetGoldenAgeProgressThreshold(),
+  GoldenAgeTurnsLeft = pPlayer:GetGoldenAgeTurns(),
+
+  -- Per-city breakdown
+  CityHappiness = {},
+
+  -- Warnings
+  Warnings = {},
+}
+
+-- Calculate turns to golden age if not in one
+if not result.IsGoldenAge and result.NetHappiness > 0 then
+  local remaining = result.GoldenAgeThreshold - result.GoldenAgeProgress
+  result.TurnsToGoldenAge = math.ceil(remaining / result.NetHappiness)
+end
+
+-- Per-city happiness
+for city in pPlayer:Cities() do
+  local cityData = {
+    Name = city:GetName(),
+    LocalHappiness = city:GetLocalHappiness(),
+    Unhappiness = city:GetUnhappinessFromCulture() + city:GetUnhappinessFromDefense() +
+                  city:GetUnhappinessFromGold() + city:GetUnhappinessFromScience() +
+                  city:GetUnhappinessFromConnection(),
+  }
+
+  -- Check for resistance
+  if city:IsResistance() then
+    cityData.IsResistance = true
+    cityData.ResistanceTurns = city:GetResistanceTurns()
+  end
+
+  -- Check for occupation
+  if city:IsOccupied() and not city:IsNoOccupiedUnhappiness() then
+    cityData.IsOccupied = true
+  end
+
+  -- Check for WLTKD
+  if city:GetWeLoveTheKingDayCounter() > 0 then
+    cityData.WLTKD = city:GetWeLoveTheKingDayCounter()
+  end
+
+  table.insert(result.CityHappiness, cityData)
+end
+
+-- Generate warnings
+if result.NetHappiness < 0 then
+  table.insert(result.Warnings, "Empire is unhappy! Growth and combat effectiveness reduced.")
+end
+
+if result.NetHappiness < -10 then
+  table.insert(result.Warnings, "Very unhappy! Risk of rebels spawning.")
+end
+
+local publicOpinionUnhappiness = pPlayer:GetUnhappinessFromPublicOpinion()
+if publicOpinionUnhappiness > 0 then
+  local preferredIdeology = pPlayer:GetPublicOpinionPreferredIdeology()
+  if preferredIdeology >= 0 then
+    local ideologyInfo = GameInfo.PolicyBranchTypes[preferredIdeology]
+    if ideologyInfo then
+      table.insert(result.Warnings, "Public opinion unhappiness: People prefer " ..
+        Locale.ConvertTextKey(ideologyInfo.Description))
+    end
+  end
+end
+
+-- Count cities in resistance
+local resistanceCount = 0
+for city in pPlayer:Cities() do
+  if city:IsResistance() then
+    resistanceCount = resistanceCount + 1
+  end
+end
+if resistanceCount > 0 then
+  table.insert(result.Warnings, resistanceCount .. " cities in resistance")
+end
+
+return result

--- a/mcp-server/lua/get-map-region.lua
+++ b/mcp-server/lua/get-map-region.lua
@@ -1,0 +1,328 @@
+-- Get map region data for AI accessibility
+-- Returns terrain, features, resources, improvements for specified tiles
+-- Addresses spatial awareness gap identified in Issue #469
+
+-- Input parameters (passed from TypeScript):
+-- centerX, centerY: Center coordinates for radius query
+-- radius: Tiles around center to query (max 10)
+-- playerID: Player perspective for visibility filtering
+
+local tiles = {}
+local pPlayer = Players[playerID]
+local ourTeam = pPlayer and pPlayer:GetTeam() or -1
+
+-- Helper: Get terrain name from type ID
+local function getTerrainName(terrainType)
+  if terrainType < 0 then return nil end
+  local terrainInfo = GameInfo.Terrains[terrainType]
+  if terrainInfo then
+    return Locale.ConvertTextKey(terrainInfo.Description)
+  end
+  return nil
+end
+
+-- Helper: Get feature name from type ID
+local function getFeatureName(featureType)
+  if featureType < 0 then return nil end
+  local featureInfo = GameInfo.Features[featureType]
+  if featureInfo then
+    return Locale.ConvertTextKey(featureInfo.Description)
+  end
+  return nil
+end
+
+-- Helper: Get resource info
+local function getResourceInfo(plot, playerID)
+  local resourceType = plot:GetResourceType(ourTeam)
+  if resourceType < 0 then return nil, nil, nil, nil end
+
+  local resourceInfo = GameInfo.Resources[resourceType]
+  if not resourceInfo then return nil, nil, nil, nil end
+
+  local name = Locale.ConvertTextKey(resourceInfo.Description)
+  local quantity = plot:GetNumResource()
+
+  -- Determine resource class (Bonus, Strategic, Luxury)
+  local resourceClass = "Bonus"
+  if resourceInfo.ResourceClassType == "RESOURCECLASS_LUXURY" then
+    resourceClass = "Luxury"
+  elseif resourceInfo.ResourceClassType == "RESOURCECLASS_MODERN" or
+         resourceInfo.ResourceClassType == "RESOURCECLASS_RUSH" then
+    resourceClass = "Strategic"
+  end
+
+  -- Check if improved
+  local improvementType = plot:GetImprovementType()
+  local isImproved = false
+  if improvementType >= 0 then
+    -- Check if this improvement works the resource
+    local improvementInfo = GameInfo.Improvements[improvementType]
+    if improvementInfo then
+      for row in GameInfo.Improvement_ResourceTypes() do
+        if row.ImprovementType == improvementInfo.Type and row.ResourceType == resourceInfo.Type then
+          isImproved = true
+          break
+        end
+      end
+    end
+  end
+
+  return name, quantity, resourceClass, isImproved
+end
+
+-- Helper: Get improvement name
+local function getImprovementName(improvementType)
+  if improvementType < 0 then return nil end
+  local improvementInfo = GameInfo.Improvements[improvementType]
+  if improvementInfo then
+    return Locale.ConvertTextKey(improvementInfo.Description)
+  end
+  return nil
+end
+
+-- Helper: Get route type
+local function getRouteName(routeType)
+  if routeType < 0 then return nil end
+  local routeInfo = GameInfo.Routes[routeType]
+  if routeInfo then
+    return Locale.ConvertTextKey(routeInfo.Description)
+  end
+  return nil
+end
+
+-- Helper: Get owner name
+local function getOwnerName(plot)
+  local ownerID = plot:GetOwner()
+  if ownerID < 0 then return nil end
+
+  local owner = Players[ownerID]
+  if not owner then return nil end
+
+  if owner:IsMinorCiv() then
+    return "City-State " .. owner:GetName()
+  elseif owner:IsBarbarian() then
+    return "Barbarians"
+  else
+    return owner:GetCivilizationShortDescription()
+  end
+end
+
+-- Helper: Get visibility level
+local function getVisibility(plot)
+  if not pPlayer then return "Unknown" end
+
+  if plot:IsVisible(ourTeam, false) then
+    return "Visible"
+  elseif plot:IsRevealed(ourTeam, false) then
+    return "Revealed"
+  else
+    return "Hidden"
+  end
+end
+
+-- Helper: Get units on plot (if visible)
+local function getUnitsOnPlot(plot)
+  if not plot:IsVisible(ourTeam, false) then return nil end
+
+  local units = {}
+  local numUnits = plot:GetNumUnits()
+
+  for i = 0, numUnits - 1 do
+    local pUnit = plot:GetUnit(i)
+    if pUnit and not pUnit:IsInvisible(ourTeam, false) then
+      local unitOwner = Players[pUnit:GetOwner()]
+      local ownerName = "Unknown"
+      if unitOwner then
+        if unitOwner:IsMinorCiv() then
+          ownerName = "City-State"
+        elseif unitOwner:IsBarbarian() then
+          ownerName = "Barbarians"
+        else
+          ownerName = unitOwner:GetCivilizationShortDescription()
+        end
+      end
+
+      local unitInfo = GameInfo.Units[pUnit:GetUnitType()]
+      local unitName = unitInfo and Locale.ConvertTextKey(unitInfo.Description) or "Unknown Unit"
+
+      table.insert(units, {
+        Name = unitName,
+        Owner = ownerName,
+        Strength = pUnit:GetBaseCombatStrength(),
+        RangedStrength = pUnit:GetBaseRangedCombatStrength(),
+        Health = math.floor((pUnit:GetCurrHitPoints() / pUnit:GetMaxHitPoints()) * 100)
+      })
+    end
+  end
+
+  return #units > 0 and units or nil
+end
+
+-- Helper: Calculate defense modifier for plot
+local function getDefenseModifier(plot)
+  local modifier = 0
+
+  -- Hills give defense bonus
+  if plot:IsHills() then
+    modifier = modifier + 25
+  end
+
+  -- Features can give defense
+  local featureType = plot:GetFeatureType()
+  if featureType >= 0 then
+    local featureInfo = GameInfo.Features[featureType]
+    if featureInfo and featureInfo.Defense then
+      modifier = modifier + featureInfo.Defense
+    end
+  end
+
+  -- River crossing penalty (for attackers, shown as defender bonus)
+  if plot:IsRiver() then
+    modifier = modifier + 10
+  end
+
+  return modifier
+end
+
+-- Helper: Calculate movement cost
+local function getMovementCost(plot)
+  local cost = 1
+
+  -- Hills cost extra
+  if plot:IsHills() then
+    cost = cost + 1
+  end
+
+  -- Features can add cost
+  local featureType = plot:GetFeatureType()
+  if featureType >= 0 then
+    local featureInfo = GameInfo.Features[featureType]
+    if featureInfo and featureInfo.Movement then
+      cost = cost + featureInfo.Movement
+    end
+  end
+
+  -- Rivers add cost when crossing
+  if plot:IsRiver() then
+    cost = cost + 1
+  end
+
+  return cost
+end
+
+-- Clamp radius
+if radius > 10 then radius = 10 end
+if radius < 1 then radius = 1 end
+
+-- Get map dimensions
+local mapWidth = Map.GetGridSize()
+local mapHeight = Map.GetGridSize()
+
+-- Iterate through tiles in radius
+for dx = -radius, radius do
+  for dy = -radius, radius do
+    -- Hex distance check
+    local distance = math.max(math.abs(dx), math.abs(dy), math.abs(dx + dy))
+    if distance <= radius then
+      local x = centerX + dx
+      local y = centerY + dy
+
+      -- Wrap x coordinate if needed (cylindrical map)
+      if x < 0 then x = x + mapWidth end
+      if x >= mapWidth then x = x - mapWidth end
+
+      -- Skip if y is out of bounds
+      if y >= 0 and y < mapHeight then
+        local plot = Map.GetPlot(x, y)
+
+        if plot then
+          local visibility = getVisibility(plot)
+
+          -- Only include visible or revealed tiles
+          if visibility ~= "Hidden" then
+            local tileData = {
+              X = x,
+              Y = y,
+              Visibility = visibility
+            }
+
+            -- Terrain (always available for revealed tiles)
+            tileData.Terrain = getTerrainName(plot:GetTerrainType())
+            tileData.IsHills = plot:IsHills()
+            tileData.IsMountain = plot:IsMountain()
+            tileData.Feature = getFeatureName(plot:GetFeatureType())
+
+            -- Water info
+            tileData.IsRiver = plot:IsRiver()
+            tileData.IsFreshWater = plot:IsFreshWater()
+            tileData.IsLake = plot:IsLake()
+            tileData.IsCoastal = plot:IsCoastalLand()
+
+            -- Resource info
+            local resName, resQty, resClass, resImproved = getResourceInfo(plot, playerID)
+            if resName then
+              tileData.Resource = resName
+              tileData.ResourceQuantity = resQty
+              tileData.ResourceClass = resClass
+              tileData.ResourceImproved = resImproved
+            end
+
+            -- Improvement info
+            local improvementType = plot:GetImprovementType()
+            if improvementType >= 0 then
+              tileData.Improvement = getImprovementName(improvementType)
+              tileData.ImprovementPillaged = plot:IsImprovementPillaged()
+            end
+
+            -- Route info
+            local routeType = plot:GetRouteType()
+            if routeType >= 0 then
+              tileData.Route = getRouteName(routeType)
+              tileData.RoutePillaged = plot:IsRoutePillaged()
+            end
+
+            -- Ownership
+            tileData.Owner = getOwnerName(plot)
+
+            -- City on this tile
+            local city = plot:GetPlotCity()
+            if city then
+              tileData.City = city:GetName()
+            end
+
+            -- Working city (if owned by us)
+            local workingCity = plot:GetWorkingCity()
+            if workingCity and workingCity:GetOwner() == playerID then
+              tileData.WorkedByCity = workingCity:GetName()
+            end
+
+            -- Units (only if visible)
+            if visibility == "Visible" then
+              tileData.Units = getUnitsOnPlot(plot)
+            end
+
+            -- Combat modifiers
+            tileData.DefenseModifier = getDefenseModifier(plot)
+            tileData.MovementCost = getMovementCost(plot)
+
+            -- Yields (if we own or can see details)
+            if visibility == "Visible" then
+              tileData.Yields = {
+                Food = plot:GetYield(GameInfoTypes.YIELD_FOOD),
+                Production = plot:GetYield(GameInfoTypes.YIELD_PRODUCTION),
+                Gold = plot:GetYield(GameInfoTypes.YIELD_GOLD),
+                Science = plot:GetYield(GameInfoTypes.YIELD_SCIENCE),
+                Culture = plot:GetYield(GameInfoTypes.YIELD_CULTURE),
+                Faith = plot:GetYield(GameInfoTypes.YIELD_FAITH)
+              }
+            end
+
+            table.insert(tiles, tileData)
+          end
+        end
+      end
+    end
+  end
+end
+
+return tiles

--- a/mcp-server/lua/get-trade-routes.lua
+++ b/mcp-server/lua/get-trade-routes.lua
@@ -1,0 +1,87 @@
+-- Get trade route info for AI accessibility
+-- Returns active routes with yields
+-- Addresses trade route gap identified in Issue #469
+
+local pPlayer = Players[playerID]
+if not pPlayer then
+  return nil
+end
+
+local result = {
+  -- Summary
+  TotalRoutes = pPlayer:GetNumInternationalTradeRoutesUsed(),
+  AvailableSlots = pPlayer:GetNumInternationalTradeRoutesAvailable() - pPlayer:GetNumInternationalTradeRoutesUsed(),
+  MaxRoutes = pPlayer:GetNumInternationalTradeRoutesAvailable(),
+
+  -- Active routes
+  ActiveRoutes = {},
+
+  -- Idle trade units (can establish new routes)
+  IdleTradeUnits = {},
+}
+
+-- Get all trade routes
+local tradeRoutes = pPlayer:GetTradeRoutes()
+for i, route in ipairs(tradeRoutes) do
+  local fromCity = pPlayer:GetCityByID(route.FromID)
+  local toPlayer = Players[route.ToPlayerID]
+  local toCity = toPlayer and toPlayer:GetCityByID(route.ToID) or nil
+
+  if fromCity and toCity then
+    local routeData = {
+      Domain = route.Domain == GameInfoTypes.DOMAIN_SEA and "Sea" or "Land",
+      FromCity = fromCity:GetName(),
+      ToCity = toCity:GetName(),
+      ToCiv = toPlayer:GetCivilizationShortDescription(),
+
+      TurnsRemaining = route.TurnsLeft,
+
+      -- Is it internal?
+      IsInternal = route.ToPlayerID == playerID,
+    }
+
+    -- Get yields
+    -- Gold yields
+    routeData.FromGold = route.FromGPT or 0
+    routeData.ToGold = route.ToGPT or 0
+
+    -- Food/Production (internal routes)
+    if routeData.IsInternal then
+      routeData.FromFood = route.FromFood or 0
+      routeData.FromProduction = route.FromProduction or 0
+    end
+
+    -- Science from tech difference
+    routeData.FromScience = route.FromScience or 0
+    routeData.ToScience = route.ToScience or 0
+
+    -- Religious pressure
+    routeData.FromReligiousPressure = route.FromReligiousPressure or 0
+    routeData.ToReligiousPressure = route.ToReligiousPressure or 0
+
+    table.insert(result.ActiveRoutes, routeData)
+  end
+end
+
+-- Find idle trade units
+for pUnit in pPlayer:Units() do
+  local unitInfo = GameInfo.Units[pUnit:GetUnitType()]
+  if unitInfo and unitInfo.Trade then
+    -- Check if this unit has moves and isn't on a route
+    if pUnit:GetMoves() > 0 and not pUnit:IsTrade() then
+      local plot = pUnit:GetPlot()
+      local city = plot and plot:GetPlotCity() or nil
+
+      table.insert(result.IdleTradeUnits, {
+        ID = pUnit:GetID(),
+        Name = Locale.ConvertTextKey(unitInfo.Description),
+        X = pUnit:GetX(),
+        Y = pUnit:GetY(),
+        InCity = city and city:GetName() or nil,
+        Domain = unitInfo.Domain == "DOMAIN_SEA" and "Sea" or "Land",
+      })
+    end
+  end
+end
+
+return result

--- a/mcp-server/lua/get-world-congress.lua
+++ b/mcp-server/lua/get-world-congress.lua
@@ -1,0 +1,122 @@
+-- Get World Congress / United Nations info for AI accessibility
+-- Returns proposals, votes, resolutions
+-- Addresses World Congress gap identified in Issue #469
+
+local pPlayer = Players[playerID]
+if not pPlayer then
+  return nil
+end
+
+-- Get the active league
+local pLeague = nil
+for iLeague = 0, GameDefines.MAX_LEAGUES - 1 do
+  local tempLeague = Game.GetLeague(iLeague)
+  if tempLeague and tempLeague:IsInSession() or tempLeague:CanStartSession() then
+    pLeague = tempLeague
+    break
+  end
+end
+
+if not pLeague then
+  return { Active = false, Message = "No World Congress or United Nations exists yet" }
+end
+
+local result = {
+  Active = true,
+
+  -- Basic info
+  LeagueName = pLeague:GetName(),
+  IsUnitedNations = Game.IsUnitedNationsActive(),
+  HostCiv = Players[pLeague:GetHostMember()] and
+            Players[pLeague:GetHostMember()]:GetCivilizationShortDescription() or "Unknown",
+
+  -- Session status
+  InSession = pLeague:IsInSession(),
+  TurnsUntilSession = pLeague:GetTurnsUntilSession(),
+  IsSpecialSession = pLeague:IsInSpecialSession(),
+
+  -- Our voting power
+  OurVotes = pLeague:CalculateStartingVotesForMember(playerID),
+  ProposalsAvailable = pLeague:GetRemainingProposalsForMember(playerID),
+  VotesRemaining = pLeague:GetRemainingVotesForMember(playerID),
+
+  -- Diplomatic victory
+  DiploVictoryEnabled = Game.IsVictoryValid(GameInfoTypes.VICTORY_DIPLOMATIC),
+  VotesNeededForVictory = Game.GetVotesNeededForDiploVictory(),
+
+  -- Active resolutions (in effect now)
+  ActiveResolutions = {},
+
+  -- Current proposals being voted on
+  CurrentProposals = {},
+
+  -- Available to propose
+  ProposableResolutions = {},
+
+  -- Members
+  Members = {},
+}
+
+-- Get active resolutions
+for i, resolution in ipairs(pLeague:GetActiveResolutions()) do
+  local resInfo = GameInfo.Resolutions[resolution.Type]
+  if resInfo then
+    table.insert(result.ActiveResolutions, {
+      Name = Locale.ConvertTextKey(resInfo.Description),
+      ProposedBy = Players[resolution.ProposerChoice] and
+                   Players[resolution.ProposerChoice]:GetCivilizationShortDescription() or "Unknown",
+    })
+  end
+end
+
+-- Get current proposals (if in session)
+if pLeague:IsInSession() then
+  for i, proposal in ipairs(pLeague:GetEnactProposals()) do
+    local resInfo = GameInfo.Resolutions[proposal.Type]
+    if resInfo then
+      table.insert(result.CurrentProposals, {
+        Name = Locale.ConvertTextKey(resInfo.Description),
+        Type = "Enact",
+        ProposedBy = Players[proposal.ProposerChoice] and
+                     Players[proposal.ProposerChoice]:GetCivilizationShortDescription() or "Unknown",
+      })
+    end
+  end
+
+  for i, proposal in ipairs(pLeague:GetRepealProposals()) do
+    local resInfo = GameInfo.Resolutions[proposal.Type]
+    if resInfo then
+      table.insert(result.CurrentProposals, {
+        Name = Locale.ConvertTextKey(resInfo.Description),
+        Type = "Repeal",
+        ProposedBy = Players[proposal.ProposerChoice] and
+                     Players[proposal.ProposerChoice]:GetCivilizationShortDescription() or "Unknown",
+      })
+    end
+  end
+end
+
+-- Get proposable resolutions
+for resolution in GameInfo.Resolutions() do
+  local canPropose = pLeague:CanProposeEnact(resolution.ID, playerID, -1)
+  if canPropose or pLeague:IsProposed(resolution.ID, playerID, true) then
+    table.insert(result.ProposableResolutions, {
+      Name = Locale.ConvertTextKey(resolution.Description),
+      CanPropose = canPropose,
+    })
+  end
+end
+
+-- Get members
+for iPlayer = 0, GameDefines.MAX_MAJOR_CIVS - 1 do
+  local pLoopPlayer = Players[iPlayer]
+  if pLoopPlayer and pLoopPlayer:IsAlive() and pLeague:IsMember(iPlayer) then
+    table.insert(result.Members, {
+      CivName = pLoopPlayer:GetCivilizationShortDescription(),
+      Votes = pLeague:CalculateStartingVotesForMember(iPlayer),
+      IsHost = pLeague:GetHostMember() == iPlayer,
+    })
+  end
+end
+
+return result

--- a/mcp-server/src/knowledge/getters/combat-preview.ts
+++ b/mcp-server/src/knowledge/getters/combat-preview.ts
@@ -1,0 +1,182 @@
+/**
+ * Utility functions for combat preview data
+ * Provides pre-attack combat predictions for AI accessibility (Issue #469)
+ *
+ * Kali ❤️‍🔥 [Visionary]: This is decision-critical - you can't play without it
+ * Athena 🦉 [Reviewer]: Mirrors Game.GetCombatPrediction() + EnemyUnitPanel.lua
+ * Nemesis 💀 [Accessibility]: Sighted players see this at a GLANCE when hovering
+ */
+
+import { LuaFunction } from '../../bridge/lua-function.js';
+import { createLogger } from '../../utils/logger.js';
+
+const logger = createLogger('CombatPreview');
+
+/**
+ * Combat modifier source
+ */
+export interface CombatModifier {
+  Source: string;
+  Value: number;
+}
+
+/**
+ * Unit info for combat
+ */
+export interface CombatUnitInfo {
+  ID: number;
+  Name: string;
+  Owner: string;
+  X: number;
+  Y: number;
+  CurrentHP: number;
+  MaxHP: number;
+  BaseStrength: number;
+  RangedStrength?: number;
+  Moves?: number;
+  MaxMoves?: number;
+}
+
+/**
+ * Defender info (can be unit or city)
+ */
+export interface DefenderInfo {
+  ID: number;
+  Name: string;
+  Type: 'Unit' | 'City';
+  Owner: string;
+  X: number;
+  Y: number;
+  CurrentHP: number;
+  MaxHP: number;
+  BaseStrength: number;
+}
+
+/**
+ * Combat prediction result
+ */
+export interface CombatPrediction {
+  Attacker: CombatUnitInfo;
+  Defender: DefenderInfo;
+
+  // Prediction
+  Prediction: 'TotalVictory' | 'MajorVictory' | 'SmallVictory' |
+              'Stalemate' |
+              'SmallDefeat' | 'MajorDefeat' | 'TotalDefeat' |
+              'Ranged' | 'Unknown';
+
+  // Damage
+  ExpectedDamageToDefender: number;
+  ExpectedDamageToAttacker: number;
+  DefenderWouldDie: boolean;
+  AttackerWouldDie: boolean;
+
+  // Risk
+  RiskLevel: 'Safe' | 'Favorable' | 'Risky' | 'Dangerous' | 'Suicidal';
+
+  // Combat type
+  IsRanged: boolean;
+  CanCounterAttack: boolean;
+
+  // Modifiers
+  AttackerModifiers: CombatModifier[];
+  DefenderModifiers: CombatModifier[];
+}
+
+/**
+ * Lua function for combat preview
+ */
+const luaFunc = LuaFunction.fromFile(
+  'get-combat-preview.lua',
+  'getCombatPreview',
+  ['playerID', 'attackerUnitID', 'defenderUnitID', 'showAllTargets']
+);
+
+/**
+ * Get combat preview for specific attacker vs defender
+ */
+export async function getCombatPreview(
+  playerID: number,
+  attackerUnitID: number,
+  defenderUnitID?: number,
+  showAllTargets?: boolean
+): Promise<CombatPrediction[]> {
+  const response = await luaFunc.execute(
+    playerID,
+    attackerUnitID,
+    defenderUnitID ?? -1,
+    showAllTargets ?? false
+  );
+
+  if (!response.success) {
+    logger.error('Failed to get combat preview from Lua', response);
+    return [];
+  }
+
+  const predictions = response.result as CombatPrediction[];
+  logger.info(`Retrieved ${predictions.length} combat predictions for unit ${attackerUnitID}`);
+
+  return predictions;
+}
+
+/**
+ * Find the best target from a list of predictions
+ * Best = kill with minimal damage taken, or highest damage dealt if no kills
+ */
+export function findBestTarget(predictions: CombatPrediction[]): {
+  DefenderName: string;
+  Prediction: string;
+  Reason: string;
+} | undefined {
+  // Filter to safe kills first
+  const safeKills = predictions.filter(p =>
+    p.DefenderWouldDie && !p.AttackerWouldDie
+  );
+
+  if (safeKills.length > 0) {
+    // Best kill = least damage to us
+    const best = safeKills.reduce((a, b) =>
+      a.ExpectedDamageToAttacker < b.ExpectedDamageToAttacker ? a : b
+    );
+    return {
+      DefenderName: best.Defender.Name,
+      Prediction: best.Prediction,
+      Reason: `Kill with ${best.ExpectedDamageToAttacker} damage taken`,
+    };
+  }
+
+  // No kills possible - find highest damage dealt safely
+  const safeDamage = predictions.filter(p =>
+    p.RiskLevel === 'Safe' || p.RiskLevel === 'Favorable'
+  );
+
+  if (safeDamage.length > 0) {
+    const best = safeDamage.reduce((a, b) =>
+      a.ExpectedDamageToDefender > b.ExpectedDamageToDefender ? a : b
+    );
+    return {
+      DefenderName: best.Defender.Name,
+      Prediction: best.Prediction,
+      Reason: `Deal ${best.ExpectedDamageToDefender} damage safely`,
+    };
+  }
+
+  return undefined;
+}
+
+/**
+ * Find targets to avoid
+ */
+export function findAvoidTargets(predictions: CombatPrediction[]): {
+  DefenderName: string;
+  Reason: string;
+}[] {
+  return predictions
+    .filter(p => p.AttackerWouldDie || p.RiskLevel === 'Suicidal' || p.RiskLevel === 'Dangerous')
+    .map(p => ({
+      DefenderName: p.Defender.Name,
+      Reason: p.AttackerWouldDie
+        ? 'Would result in our death'
+        : 'Extremely unfavorable odds',
+    }));
+}

--- a/mcp-server/src/knowledge/getters/culture-influence.ts
+++ b/mcp-server/src/knowledge/getters/culture-influence.ts
@@ -1,0 +1,61 @@
+/**
+ * Culture/Tourism influence getter for AI accessibility (Issue #469)
+ */
+
+import { LuaFunction } from '../../bridge/lua-function.js';
+import { createLogger } from '../../utils/logger.js';
+
+const logger = createLogger('CultureInfluence');
+
+export interface InfluenceData {
+  CivName: string;
+  InfluenceLevel: 'Unknown' | 'Exotic' | 'Familiar' | 'Popular' | 'Influential' | 'Dominant';
+  InfluencePercent: number;
+  TheirCulturePerTurn?: number;
+  TourismTowardThem?: number;
+  TurnsToNextLevel?: number;
+}
+
+export interface CityCulture {
+  Name: string;
+  CulturePerTurn: number;
+  TourismPerTurn: number;
+  GreatWorks: number;
+}
+
+export interface CultureInfluenceData {
+  OurCulturePerTurn: number;
+  OurTourismPerTurn: number;
+
+  OurIdeology?: string;
+  IdeologyLevel: number;
+
+  InfluenceOnOthers: InfluenceData[];
+  InfluenceOnUs: InfluenceData[];
+
+  PublicOpinion: 'Content' | 'Dissidents' | 'Civil Resistance' | 'Revolutionary Wave';
+  PublicOpinionUnhappiness: number;
+  PreferredIdeology?: string;
+
+  GreatWorksCount: number;
+  ThemedBonuses: number;
+
+  CultureByCity: CityCulture[];
+}
+
+const luaFunc = LuaFunction.fromFile(
+  'get-culture-influence.lua',
+  'getCultureInfluence',
+  ['playerID']
+);
+
+export async function getCultureInfluence(playerID: number): Promise<CultureInfluenceData | null> {
+  const response = await luaFunc.execute(playerID);
+
+  if (!response.success) {
+    logger.error('Failed to get culture influence from Lua', response);
+    return null;
+  }
+
+  return response.result as CultureInfluenceData;
+}

--- a/mcp-server/src/knowledge/getters/espionage.ts
+++ b/mcp-server/src/knowledge/getters/espionage.ts
@@ -1,0 +1,57 @@
+/**
+ * Espionage getter for AI accessibility (Issue #469)
+ */
+
+import { LuaFunction } from '../../bridge/lua-function.js';
+import { createLogger } from '../../utils/logger.js';
+
+const logger = createLogger('Espionage');
+
+export interface Spy {
+  Name: string;
+  Rank: number;
+  Location?: string;
+  LocationOwner?: string;
+  State: 'Unassigned' | 'Travelling' | 'GatheringIntel' | 'CounterIntelligence' |
+         'Schmoozing' | 'RiggingElection' | 'StagingCoup' | 'Diplomat' | 'Surveillance' | 'Unknown';
+  TurnsInState?: number;
+}
+
+export interface CityIntel {
+  CityName: string;
+  Owner: string;
+  Population?: number;
+  HasOurSpy: boolean;
+  EspionagePotential?: number;
+  IsCapital?: boolean;
+  IsOurCity?: boolean;
+}
+
+export interface IntrigueMessage {
+  Turn: number;
+  Message: string;
+  SpyName?: string;
+}
+
+export interface EspionageData {
+  Spies: Spy[];
+  CityIntelligence: CityIntel[];
+  IntrigueMessages: IntrigueMessage[];
+}
+
+const luaFunc = LuaFunction.fromFile(
+  'get-espionage.lua',
+  'getEspionage',
+  ['playerID']
+);
+
+export async function getEspionage(playerID: number): Promise<EspionageData | null> {
+  const response = await luaFunc.execute(playerID);
+
+  if (!response.success) {
+    logger.error('Failed to get espionage from Lua', response);
+    return null;
+  }
+
+  return response.result as EspionageData;
+}

--- a/mcp-server/src/knowledge/getters/happiness.ts
+++ b/mcp-server/src/knowledge/getters/happiness.ts
@@ -1,0 +1,74 @@
+/**
+ * Happiness breakdown getter for AI accessibility (Issue #469)
+ */
+
+import { LuaFunction } from '../../bridge/lua-function.js';
+import { createLogger } from '../../utils/logger.js';
+
+const logger = createLogger('Happiness');
+
+export interface CityHappiness {
+  Name: string;
+  LocalHappiness: number;
+  Unhappiness: number;
+  IsResistance?: boolean;
+  ResistanceTurns?: number;
+  IsOccupied?: boolean;
+  WLTKD?: number;
+}
+
+export interface HappinessData {
+  TotalHappiness: number;
+  TotalUnhappiness: number;
+  NetHappiness: number;
+
+  HappinessSources: {
+    FromCities: number;
+    FromTradeRoutes: number;
+    FromReligion: number;
+    FromNaturalWonders: number;
+    FromMinorCivs: number;
+    FromLeagues: number;
+    FromVassals: number;
+    FromLuxuries: number;
+    FromPolicies: number;
+    FromBuildings: number;
+    FromExtraHappinessPerCity: number;
+  };
+
+  UnhappinessSources: {
+    FromCities: number;
+    FromPopulation: number;
+    FromOccupation: number;
+    FromPublicOpinion: number;
+    FromUnits: number;
+    FromCitySpecialists: number;
+    FromWarWeariness: number;
+  };
+
+  IsGoldenAge: boolean;
+  GoldenAgeProgress: number;
+  GoldenAgeThreshold: number;
+  GoldenAgeTurnsLeft: number;
+  TurnsToGoldenAge?: number;
+
+  CityHappiness: CityHappiness[];
+  Warnings: string[];
+}
+
+const luaFunc = LuaFunction.fromFile(
+  'get-happiness.lua',
+  'getHappiness',
+  ['playerID']
+);
+
+export async function getHappiness(playerID: number): Promise<HappinessData | null> {
+  const response = await luaFunc.execute(playerID);
+
+  if (!response.success) {
+    logger.error('Failed to get happiness from Lua', response);
+    return null;
+  }
+
+  return response.result as HappinessData;
+}

--- a/mcp-server/src/knowledge/getters/map-region.ts
+++ b/mcp-server/src/knowledge/getters/map-region.ts
@@ -1,0 +1,206 @@
+/**
+ * Utility functions for extracting map region data
+ * Provides spatial awareness for AI accessibility (Issue #469)
+ *
+ * Kali ❤️‍🔥 [Visionary]: This bridges the gap between "what exists" and "where it is"
+ * Athena 🦉 [Reviewer]: Mirrors data from PlotMouseoverInclude.lua
+ * Nemesis 💀 [Accessibility]: Sighted players see this at a GLANCE - now AI can too
+ */
+
+import { LuaFunction } from '../../bridge/lua-function.js';
+import { createLogger } from '../../utils/logger.js';
+
+const logger = createLogger('MapRegion');
+
+/**
+ * Unit data on a tile
+ */
+export interface TileUnit {
+  Name: string;
+  Owner: string;
+  Strength?: number;
+  RangedStrength?: number;
+  Health: number;
+}
+
+/**
+ * Yield data for a tile
+ */
+export interface TileYields {
+  Food: number;
+  Production: number;
+  Gold: number;
+  Science: number;
+  Culture: number;
+  Faith: number;
+}
+
+/**
+ * Complete tile data structure
+ */
+export interface TileData {
+  // Location
+  X: number;
+  Y: number;
+
+  // Visibility
+  Visibility: 'Visible' | 'Revealed' | 'Hidden';
+
+  // Terrain
+  Terrain?: string;
+  IsHills?: boolean;
+  IsMountain?: boolean;
+  Feature?: string;
+
+  // Water
+  IsRiver?: boolean;
+  IsFreshWater?: boolean;
+  IsLake?: boolean;
+  IsCoastal?: boolean;
+
+  // Resources
+  Resource?: string;
+  ResourceQuantity?: number;
+  ResourceClass?: 'Bonus' | 'Strategic' | 'Luxury';
+  ResourceImproved?: boolean;
+
+  // Improvements
+  Improvement?: string;
+  ImprovementPillaged?: boolean;
+  Route?: string;
+  RoutePillaged?: boolean;
+
+  // Ownership
+  Owner?: string;
+  City?: string;
+  WorkedByCity?: string;
+
+  // Units
+  Units?: TileUnit[];
+
+  // Combat modifiers
+  DefenseModifier?: number;
+  MovementCost?: number;
+
+  // Yields
+  Yields?: TileYields;
+}
+
+/**
+ * Lua function that extracts map region data
+ */
+const luaFunc = LuaFunction.fromFile(
+  'get-map-region.lua',
+  'getMapRegion',
+  ['centerX', 'centerY', 'radius', 'playerID']
+);
+
+/**
+ * Get tile data for a region centered on a point
+ * @param centerX - X coordinate of region center
+ * @param centerY - Y coordinate of region center
+ * @param radius - Radius in tiles (max 10)
+ * @param playerID - Player ID for visibility filtering
+ * @returns Array of TileData for visible/revealed tiles
+ */
+export async function getMapRegion(
+  centerX: number,
+  centerY: number,
+  radius: number,
+  playerID: number
+): Promise<TileData[]> {
+  // Clamp radius
+  const clampedRadius = Math.min(Math.max(radius, 1), 10);
+
+  const response = await luaFunc.execute(centerX, centerY, clampedRadius, playerID);
+
+  if (!response.success) {
+    logger.error('Failed to get map region from Lua', response);
+    return [];
+  }
+
+  const tiles = response.result as TileData[];
+  logger.info(`Retrieved ${tiles.length} tiles for region (${centerX},${centerY}) r=${clampedRadius}`);
+
+  return tiles;
+}
+
+/**
+ * Generate spatial notes describing notable features in the tile data
+ * This is the key accessibility feature - describing what a sighted player would notice
+ *
+ * Kali ❤️‍🔥 [Visionary]: Translate visual patterns to text
+ * Nemesis 💀 [Accessibility]: A sighted player sees "mountain range with gap" - we say it
+ */
+export function generateSpatialNotes(tiles: TileData[]): string[] {
+  const notes: string[] = [];
+
+  // Group tiles by type for analysis
+  const mountains: TileData[] = [];
+  const rivers: TileData[] = [];
+  const resources: Map<string, TileData[]> = new Map();
+  const cities: TileData[] = [];
+  const enemyUnits: TileData[] = [];
+
+  for (const tile of tiles) {
+    if (tile.IsMountain) {
+      mountains.push(tile);
+    }
+    if (tile.IsRiver) {
+      rivers.push(tile);
+    }
+    if (tile.Resource) {
+      const existing = resources.get(tile.Resource) || [];
+      existing.push(tile);
+      resources.set(tile.Resource, existing);
+    }
+    if (tile.City) {
+      cities.push(tile);
+    }
+    if (tile.Units && tile.Units.length > 0) {
+      enemyUnits.push(tile);
+    }
+  }
+
+  // Note mountain clusters
+  if (mountains.length >= 3) {
+    const coords = mountains.map(t => `(${t.X},${t.Y})`).join(', ');
+    notes.push(`Mountain range: ${mountains.length} peaks at ${coords}`);
+  }
+
+  // Note resource clusters
+  for (const [resourceName, resourceTiles] of resources) {
+    if (resourceTiles.length >= 2) {
+      const coords = resourceTiles.map(t => `(${t.X},${t.Y})`).join(', ');
+      const improved = resourceTiles.filter(t => t.ResourceImproved).length;
+      notes.push(`${resourceName} cluster: ${resourceTiles.length} at ${coords} (${improved} improved)`);
+    }
+  }
+
+  // Note cities
+  for (const tile of cities) {
+    notes.push(`City "${tile.City}" at (${tile.X},${tile.Y}) owned by ${tile.Owner || 'unknown'}`);
+  }
+
+  // Note visible enemy units
+  for (const tile of enemyUnits) {
+    if (tile.Units) {
+      for (const unit of tile.Units) {
+        if (unit.Strength && unit.Strength > 0) {
+          notes.push(`${unit.Owner} ${unit.Name} (${unit.Strength} str, ${unit.Health}% hp) at (${tile.X},${tile.Y})`);
+        }
+      }
+    }
+  }
+
+  // Note defensive positions (hills with good defense)
+  const defensivePositions = tiles.filter(t =>
+    t.IsHills && !t.IsMountain && (t.DefenseModifier || 0) >= 25
+  );
+  if (defensivePositions.length >= 2) {
+    const coords = defensivePositions.slice(0, 3).map(t => `(${t.X},${t.Y})`).join(', ');
+    notes.push(`Defensive terrain: ${defensivePositions.length} hill positions including ${coords}`);
+  }
+
+  return notes;
+}

--- a/mcp-server/src/knowledge/getters/trade-routes.ts
+++ b/mcp-server/src/knowledge/getters/trade-routes.ts
@@ -1,0 +1,60 @@
+/**
+ * Trade routes getter for AI accessibility (Issue #469)
+ */
+
+import { LuaFunction } from '../../bridge/lua-function.js';
+import { createLogger } from '../../utils/logger.js';
+
+const logger = createLogger('TradeRoutes');
+
+export interface TradeRoute {
+  Domain: 'Land' | 'Sea';
+  FromCity: string;
+  ToCity: string;
+  ToCiv: string;
+  TurnsRemaining: number;
+  IsInternal: boolean;
+
+  FromGold: number;
+  ToGold: number;
+  FromFood?: number;
+  FromProduction?: number;
+  FromScience?: number;
+  ToScience?: number;
+  FromReligiousPressure?: number;
+  ToReligiousPressure?: number;
+}
+
+export interface IdleTradeUnit {
+  ID: number;
+  Name: string;
+  X: number;
+  Y: number;
+  InCity?: string;
+  Domain: 'Land' | 'Sea';
+}
+
+export interface TradeRoutesData {
+  TotalRoutes: number;
+  AvailableSlots: number;
+  MaxRoutes: number;
+  ActiveRoutes: TradeRoute[];
+  IdleTradeUnits: IdleTradeUnit[];
+}
+
+const luaFunc = LuaFunction.fromFile(
+  'get-trade-routes.lua',
+  'getTradeRoutes',
+  ['playerID']
+);
+
+export async function getTradeRoutes(playerID: number): Promise<TradeRoutesData | null> {
+  const response = await luaFunc.execute(playerID);
+
+  if (!response.success) {
+    logger.error('Failed to get trade routes from Lua', response);
+    return null;
+  }
+
+  return response.result as TradeRoutesData;
+}

--- a/mcp-server/src/knowledge/getters/world-congress.ts
+++ b/mcp-server/src/knowledge/getters/world-congress.ts
@@ -1,0 +1,63 @@
+/**
+ * World Congress getter for AI accessibility (Issue #469)
+ */
+
+import { LuaFunction } from '../../bridge/lua-function.js';
+import { createLogger } from '../../utils/logger.js';
+
+const logger = createLogger('WorldCongress');
+
+export interface Resolution {
+  Name: string;
+  ProposedBy: string;
+  Type?: 'Enact' | 'Repeal';
+  CanPropose?: boolean;
+}
+
+export interface CongressMember {
+  CivName: string;
+  Votes: number;
+  IsHost: boolean;
+}
+
+export interface WorldCongressData {
+  Active: boolean;
+  Message?: string;
+
+  LeagueName?: string;
+  IsUnitedNations?: boolean;
+  HostCiv?: string;
+
+  InSession?: boolean;
+  TurnsUntilSession?: number;
+  IsSpecialSession?: boolean;
+
+  OurVotes?: number;
+  ProposalsAvailable?: number;
+  VotesRemaining?: number;
+
+  DiploVictoryEnabled?: boolean;
+  VotesNeededForVictory?: number;
+
+  ActiveResolutions?: Resolution[];
+  CurrentProposals?: Resolution[];
+  ProposableResolutions?: Resolution[];
+  Members?: CongressMember[];
+}
+
+const luaFunc = LuaFunction.fromFile(
+  'get-world-congress.lua',
+  'getWorldCongress',
+  ['playerID']
+);
+
+export async function getWorldCongress(playerID: number): Promise<WorldCongressData | null> {
+  const response = await luaFunc.execute(playerID);
+
+  if (!response.success) {
+    logger.error('Failed to get world congress from Lua', response);
+    return null;
+  }
+
+  return response.result as WorldCongressData;
+}

--- a/mcp-server/src/tools/actions/assign-trade-route.ts
+++ b/mcp-server/src/tools/actions/assign-trade-route.ts
@@ -1,0 +1,102 @@
+/**
+ * Trade route assignment tool for AI player control
+ */
+
+import { LuaFunctionTool } from "../abstract/lua-function.js";
+import * as z from "zod";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { MaxMajorCivs } from "../../knowledge/schema/base.js";
+
+const AssignTradeRouteResultSchema = z.object({
+  Success: z.boolean(),
+  UnitID: z.number(),
+  FromCity: z.string().optional(),
+  ToCity: z.string().optional(),
+  Message: z.string().optional(),
+});
+
+type AssignTradeRouteResultType = z.infer<typeof AssignTradeRouteResultSchema>;
+
+class AssignTradeRouteTool extends LuaFunctionTool<AssignTradeRouteResultType> {
+  readonly name = "assign-trade-route";
+
+  readonly description = `Assign a trade unit (caravan or cargo ship) to a trade route.
+
+The trade unit must be in a city. Use get-trade-routes to see idle trade
+units and potential destinations.`;
+
+  inputSchema = z.object({
+    PlayerID: z.number().min(0).max(MaxMajorCivs - 1)
+      .describe("Player ID (owner of the trade unit)"),
+    UnitID: z.number()
+      .describe("The trade unit's ID (caravan or cargo ship)"),
+    DestinationCityOwnerID: z.number()
+      .describe("Player ID of the destination city owner"),
+    DestinationCityID: z.number()
+      .describe("Destination city's ID"),
+  });
+
+  protected resultSchema = AssignTradeRouteResultSchema;
+  protected arguments = ["playerID", "unitID", "destOwnerID", "destCityID"];
+
+  readonly annotations: ToolAnnotations = {
+    readOnlyHint: false
+  };
+
+  protected script = `
+    local player = Players[playerID]
+    if not player then
+      return { Success = false, UnitID = unitID, Message = "Invalid player" }
+    end
+
+    local unit = player:GetUnitByID(unitID)
+    if not unit then
+      return { Success = false, UnitID = unitID, Message = "Trade unit not found" }
+    end
+
+    -- Check if this is a trade unit
+    if not unit:IsTrade() then
+      return { Success = false, UnitID = unitID, Message = "Unit is not a trade unit" }
+    end
+
+    local destPlayer = Players[destOwnerID]
+    if not destPlayer then
+      return { Success = false, UnitID = unitID, Message = "Invalid destination owner" }
+    end
+
+    local destCity = destPlayer:GetCityByID(destCityID)
+    if not destCity then
+      return { Success = false, UnitID = unitID, Message = "Destination city not found" }
+    end
+
+    local destPlot = destCity:Plot()
+    local fromPlot = unit:GetPlot()
+    local fromCity = fromPlot:GetPlotCity()
+    local fromCityName = fromCity and fromCity:GetName() or "Unknown"
+    local toCityName = destCity:GetName()
+
+    -- Check if we can make this trade route
+    if not unit:CanMakeTradeRouteAt(destPlot, destPlot:GetX(), destPlot:GetY()) then
+      return { Success = false, UnitID = unitID, FromCity = fromCityName, ToCity = toCityName, Message = "Cannot establish trade route to this city" }
+    end
+
+    -- Establish the trade route
+    unit:PushMission(MissionTypes.MISSION_ESTABLISH_TRADE_ROUTE, destPlot:GetX(), destPlot:GetY())
+
+    return {
+      Success = true,
+      UnitID = unitID,
+      FromCity = fromCityName,
+      ToCity = toCityName,
+      Message = "Trade route established from " .. fromCityName .. " to " .. toCityName
+    }
+  `;
+
+  async execute(args: z.infer<typeof this.inputSchema>): Promise<z.infer<typeof this.outputSchema>> {
+    return await super.call(args.PlayerID, args.UnitID, args.DestinationCityOwnerID, args.DestinationCityID);
+  }
+}
+
+export default function createAssignTradeRouteTool() {
+  return new AssignTradeRouteTool();
+}

--- a/mcp-server/src/tools/actions/attack-unit.ts
+++ b/mcp-server/src/tools/actions/attack-unit.ts
@@ -1,0 +1,124 @@
+/**
+ * Melee attack tool for AI player control
+ * Kali ❤️‍🔥 [Visionary]: Combat! The heart of Civ
+ * Athena 🦉 [Reviewer]: Use get-combat-preview first to know if this is wise
+ */
+
+import { LuaFunctionTool } from "../abstract/lua-function.js";
+import * as z from "zod";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { MaxMajorCivs } from "../../knowledge/schema/base.js";
+
+const AttackResultSchema = z.object({
+  Success: z.boolean(),
+  AttackerID: z.number(),
+  TargetX: z.number(),
+  TargetY: z.number(),
+  AttackerDamageDealt: z.number().optional(),
+  AttackerDamageTaken: z.number().optional(),
+  DefenderKilled: z.boolean().optional(),
+  AttackerKilled: z.boolean().optional(),
+  Message: z.string().optional(),
+});
+
+type AttackResultType = z.infer<typeof AttackResultSchema>;
+
+class AttackUnitTool extends LuaFunctionTool<AttackResultType> {
+  readonly name = "attack-unit";
+
+  readonly description = `Execute a melee attack against a target tile.
+
+The attacking unit will move to the target and engage in combat.
+Use get-combat-preview first to see expected damage before committing.
+The attacker must have movement points and be able to reach the target.`;
+
+  inputSchema = z.object({
+    PlayerID: z.number().min(0).max(MaxMajorCivs - 1)
+      .describe("Player ID (owner of the attacking unit)"),
+    UnitID: z.number()
+      .describe("The attacking unit's ID"),
+    TargetX: z.number().min(0)
+      .describe("Target tile X coordinate (where the enemy is)"),
+    TargetY: z.number().min(0)
+      .describe("Target tile Y coordinate (where the enemy is)"),
+  });
+
+  protected resultSchema = AttackResultSchema;
+  protected arguments = ["playerID", "unitID", "targetX", "targetY"];
+
+  readonly annotations: ToolAnnotations = {
+    readOnlyHint: false
+  };
+
+  // Nemesis 💀 [Security]: Track damage dealt for strategic learning
+  // Vesta 🔥 [Builder]: Return enough info to understand what happened
+  protected script = `
+    local player = Players[playerID]
+    if not player then
+      return { Success = false, AttackerID = unitID, TargetX = targetX, TargetY = targetY, Message = "Invalid player" }
+    end
+
+    local unit = player:GetUnitByID(unitID)
+    if not unit then
+      return { Success = false, AttackerID = unitID, TargetX = targetX, TargetY = targetY, Message = "Unit not found" }
+    end
+
+    if unit:MovesLeft() <= 0 then
+      return { Success = false, AttackerID = unitID, TargetX = targetX, TargetY = targetY, Message = "No movement points" }
+    end
+
+    local targetPlot = Map.GetPlot(targetX, targetY)
+    if not targetPlot then
+      return { Success = false, AttackerID = unitID, TargetX = targetX, TargetY = targetY, Message = "Invalid target coordinates" }
+    end
+
+    -- Check for enemy unit at target
+    local defenderCount = targetPlot:GetNumUnits()
+    if defenderCount == 0 then
+      return { Success = false, AttackerID = unitID, TargetX = targetX, TargetY = targetY, Message = "No unit at target" }
+    end
+
+    local attackerHPBefore = unit:GetCurrHitPoints()
+
+    -- Get defender info before attack
+    local defender = targetPlot:GetUnit(0)
+    local defenderHPBefore = defender and defender:GetCurrHitPoints() or 0
+
+    -- Execute the attack by moving to the target (melee attacks happen automatically)
+    unit:PushMission(MissionTypes.MISSION_MOVE_TO, targetX, targetY, 0, false, false, MissionAITypes.MISSIONAI_ASSAULT, nil, nil)
+
+    -- Check results
+    local attackerAlive = unit:IsAlive() if unit.IsAlive then attackerAlive = unit:IsAlive() else attackerAlive = true end
+    local attackerHPAfter = attackerAlive and unit:GetCurrHitPoints() or 0
+
+    -- Try to find if defender still exists
+    local defenderAlive = false
+    if defender and defender.IsAlive then
+      defenderAlive = defender:IsAlive()
+    end
+    local defenderHPAfter = defenderAlive and defender:GetCurrHitPoints() or 0
+
+    local damageDealt = defenderHPBefore - defenderHPAfter
+    local damageTaken = attackerHPBefore - attackerHPAfter
+
+    return {
+      Success = true,
+      AttackerID = unitID,
+      TargetX = targetX,
+      TargetY = targetY,
+      AttackerDamageDealt = damageDealt,
+      AttackerDamageTaken = damageTaken,
+      DefenderKilled = not defenderAlive,
+      AttackerKilled = not attackerAlive,
+      Message = "Attack executed"
+    }
+  `;
+
+  async execute(args: z.infer<typeof this.inputSchema>): Promise<z.infer<typeof this.outputSchema>> {
+    return await super.call(args.PlayerID, args.UnitID, args.TargetX, args.TargetY);
+  }
+}
+
+export default function createAttackUnitTool() {
+  return new AttackUnitTool();
+}

--- a/mcp-server/src/tools/actions/build-improvement.ts
+++ b/mcp-server/src/tools/actions/build-improvement.ts
@@ -1,0 +1,110 @@
+/**
+ * Worker improvement tool for AI player control
+ * Kali ❤️‍🔥 [Visionary]: Farms, mines, roads - the infrastructure of empire
+ * Vesta 🔥 [Builder]: MISSION_BUILD with improvement type
+ */
+
+import { LuaFunctionTool } from "../abstract/lua-function.js";
+import * as z from "zod";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { MaxMajorCivs } from "../../knowledge/schema/base.js";
+
+const BuildImprovementResultSchema = z.object({
+  Success: z.boolean(),
+  UnitID: z.number(),
+  X: z.number(),
+  Y: z.number(),
+  ImprovementName: z.string().optional(),
+  TurnsToComplete: z.number().optional(),
+  Message: z.string().optional(),
+});
+
+type BuildImprovementResultType = z.infer<typeof BuildImprovementResultSchema>;
+
+class BuildImprovementTool extends LuaFunctionTool<BuildImprovementResultType> {
+  readonly name = "build-improvement";
+
+  readonly description = `Order a worker to build an improvement on their current tile.
+
+Common improvement type IDs:
+- Farm, Mine, Lumber Mill, Trading Post, etc.
+Use get-map-region to see what improvements are valid for each tile.
+The worker must be on the tile where you want the improvement.`;
+
+  inputSchema = z.object({
+    PlayerID: z.number().min(0).max(MaxMajorCivs - 1)
+      .describe("Player ID (owner of the worker)"),
+    UnitID: z.number()
+      .describe("The worker unit's ID"),
+    BuildTypeID: z.number()
+      .describe("The build type ID (improvement to construct)"),
+  });
+
+  protected resultSchema = BuildImprovementResultSchema;
+  protected arguments = ["playerID", "unitID", "buildTypeID"];
+
+  readonly annotations: ToolAnnotations = {
+    readOnlyHint: false
+  };
+
+  // Athena 🦉 [Reviewer]: Workers use MISSION_BUILD, not improvements directly
+  // The buildTypeID maps to a Build entry which creates an improvement
+  protected script = `
+    local player = Players[playerID]
+    if not player then
+      return { Success = false, UnitID = unitID, X = -1, Y = -1, Message = "Invalid player" }
+    end
+
+    local unit = player:GetUnitByID(unitID)
+    if not unit then
+      return { Success = false, UnitID = unitID, X = -1, Y = -1, Message = "Unit not found" }
+    end
+
+    local x = unit:GetX()
+    local y = unit:GetY()
+    local plot = unit:GetPlot()
+
+    -- Check if this is a worker-type unit
+    if not unit:IsWork() then
+      return { Success = false, UnitID = unitID, X = x, Y = y, Message = "Unit cannot build improvements" }
+    end
+
+    -- Get build info
+    local buildInfo = GameInfo.Builds[buildTypeID]
+    if not buildInfo then
+      return { Success = false, UnitID = unitID, X = x, Y = y, Message = "Invalid build type" }
+    end
+
+    -- Check if this build can be done on this plot
+    if not unit:CanBuild(plot, buildTypeID) then
+      return { Success = false, UnitID = unitID, X = x, Y = y, Message = "Cannot build this improvement here" }
+    end
+
+    -- Push the build mission
+    unit:PushMission(MissionTypes.MISSION_BUILD, buildTypeID, -1, 0, false, false, MissionAITypes.MISSIONAI_BUILD, nil, nil)
+
+    -- Get improvement name
+    local improvementName = Locale.ConvertTextKey(buildInfo.Description) or buildInfo.Type
+
+    -- Calculate turns (approximate)
+    local turnsLeft = unit:GetBuildTurnsLeft(buildTypeID, plot)
+
+    return {
+      Success = true,
+      UnitID = unitID,
+      X = x,
+      Y = y,
+      ImprovementName = improvementName,
+      TurnsToComplete = turnsLeft,
+      Message = "Building " .. improvementName
+    }
+  `;
+
+  async execute(args: z.infer<typeof this.inputSchema>): Promise<z.infer<typeof this.outputSchema>> {
+    return await super.call(args.PlayerID, args.UnitID, args.BuildTypeID);
+  }
+}
+
+export default function createBuildImprovementTool() {
+  return new BuildImprovementTool();
+}

--- a/mcp-server/src/tools/actions/city-purchase.ts
+++ b/mcp-server/src/tools/actions/city-purchase.ts
@@ -1,0 +1,131 @@
+/**
+ * City purchase tool for buying units/buildings with gold
+ */
+
+import { LuaFunctionTool } from "../abstract/lua-function.js";
+import * as z from "zod";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { MaxMajorCivs } from "../../knowledge/schema/base.js";
+
+const CityPurchaseResultSchema = z.object({
+  Success: z.boolean(),
+  CityName: z.string().optional(),
+  PurchaseType: z.string().optional(),
+  ItemName: z.string().optional(),
+  GoldCost: z.number().optional(),
+  Message: z.string().optional(),
+});
+
+type CityPurchaseResultType = z.infer<typeof CityPurchaseResultSchema>;
+
+class CityPurchaseTool extends LuaFunctionTool<CityPurchaseResultType> {
+  readonly name = "city-purchase";
+
+  readonly description = `Purchase a unit or building instantly with gold.
+
+Specify either UnitTypeID or BuildingTypeID (not both).
+Use get-cities to see purchasable items and costs.`;
+
+  inputSchema = z.object({
+    PlayerID: z.number().min(0).max(MaxMajorCivs - 1)
+      .describe("Player ID (owner of the city)"),
+    CityID: z.number()
+      .describe("The city's ID"),
+    UnitTypeID: z.number().optional()
+      .describe("Unit type ID to purchase"),
+    BuildingTypeID: z.number().optional()
+      .describe("Building type ID to purchase"),
+  });
+
+  protected resultSchema = CityPurchaseResultSchema;
+  protected arguments = ["playerID", "cityID", "unitTypeID", "buildingTypeID"];
+
+  readonly annotations: ToolAnnotations = {
+    readOnlyHint: false
+  };
+
+  protected script = `
+    local player = Players[playerID]
+    if not player then
+      return { Success = false, Message = "Invalid player" }
+    end
+
+    local city = player:GetCityByID(cityID)
+    if not city then
+      return { Success = false, Message = "City not found" }
+    end
+
+    local cityName = city:GetName()
+    local gold = player:GetGold()
+
+    if unitTypeID and unitTypeID >= 0 then
+      local unitInfo = GameInfo.Units[unitTypeID]
+      if not unitInfo then
+        return { Success = false, CityName = cityName, Message = "Invalid unit type" }
+      end
+
+      local unitName = Locale.ConvertTextKey(unitInfo.Description)
+
+      if not city:IsCanPurchase(true, true, unitTypeID, -1, -1, YieldTypes.YIELD_GOLD) then
+        return { Success = false, CityName = cityName, ItemName = unitName, Message = "Cannot purchase this unit" }
+      end
+
+      local cost = city:GetUnitPurchaseCost(unitTypeID)
+      if gold < cost then
+        return { Success = false, CityName = cityName, ItemName = unitName, GoldCost = cost, Message = "Not enough gold" }
+      end
+
+      city:PurchaseUnit(unitTypeID, YieldTypes.YIELD_GOLD)
+
+      return {
+        Success = true,
+        CityName = cityName,
+        PurchaseType = "Unit",
+        ItemName = unitName,
+        GoldCost = cost,
+        Message = "Purchased " .. unitName
+      }
+
+    elseif buildingTypeID and buildingTypeID >= 0 then
+      local buildingInfo = GameInfo.Buildings[buildingTypeID]
+      if not buildingInfo then
+        return { Success = false, CityName = cityName, Message = "Invalid building type" }
+      end
+
+      local buildingName = Locale.ConvertTextKey(buildingInfo.Description)
+
+      if not city:IsCanPurchase(true, true, -1, buildingTypeID, -1, YieldTypes.YIELD_GOLD) then
+        return { Success = false, CityName = cityName, ItemName = buildingName, Message = "Cannot purchase this building" }
+      end
+
+      local cost = city:GetBuildingPurchaseCost(buildingTypeID)
+      if gold < cost then
+        return { Success = false, CityName = cityName, ItemName = buildingName, GoldCost = cost, Message = "Not enough gold" }
+      end
+
+      city:PurchaseBuilding(buildingTypeID, YieldTypes.YIELD_GOLD)
+
+      return {
+        Success = true,
+        CityName = cityName,
+        PurchaseType = "Building",
+        ItemName = buildingName,
+        GoldCost = cost,
+        Message = "Purchased " .. buildingName
+      }
+
+    else
+      return { Success = false, CityName = cityName, Message = "Must specify UnitTypeID or BuildingTypeID" }
+    end
+  `;
+
+  async execute(args: z.infer<typeof this.inputSchema>): Promise<z.infer<typeof this.outputSchema>> {
+    const unitTypeID = args.UnitTypeID ?? -1;
+    const buildingTypeID = args.BuildingTypeID ?? -1;
+    return await super.call(args.PlayerID, args.CityID, unitTypeID, buildingTypeID);
+  }
+}
+
+export default function createCityPurchaseTool() {
+  return new CityPurchaseTool();
+}

--- a/mcp-server/src/tools/actions/declare-war.ts
+++ b/mcp-server/src/tools/actions/declare-war.ts
@@ -1,0 +1,72 @@
+/**
+ * Declare war tool for AI player control
+ */
+
+import { LuaFunctionTool } from "../abstract/lua-function.js";
+import * as z from "zod";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { MaxMajorCivs } from "../../knowledge/schema/base.js";
+
+const DeclareWarResultSchema = z.object({
+  Success: z.boolean(),
+  TargetCiv: z.string().optional(),
+  Message: z.string().optional(),
+});
+
+type DeclareWarResultType = z.infer<typeof DeclareWarResultSchema>;
+
+class DeclareWarTool extends LuaFunctionTool<DeclareWarResultType> {
+  readonly name = "declare-war";
+
+  readonly description = `Declare war on another civilization.
+
+This is a major diplomatic action with lasting consequences.
+Use get-players to see other civilizations and their IDs.`;
+
+  inputSchema = z.object({
+    PlayerID: z.number().min(0).max(MaxMajorCivs - 1)
+      .describe("Your player ID"),
+    TargetPlayerID: z.number().min(0).max(MaxMajorCivs - 1)
+      .describe("Target civilization's player ID"),
+  });
+
+  protected resultSchema = DeclareWarResultSchema;
+  protected arguments = ["playerID", "targetPlayerID"];
+
+  readonly annotations: ToolAnnotations = {
+    readOnlyHint: false
+  };
+
+  protected script = `
+    local player = Players[playerID]
+    local targetPlayer = Players[targetPlayerID]
+
+    if not player or not targetPlayer then
+      return { Success = false, Message = "Invalid player ID" }
+    end
+
+    local myTeam = Teams[player:GetTeam()]
+    local targetTeam = targetPlayer:GetTeam()
+    local targetCivName = Locale.ConvertTextKey(GameInfo.Civilizations[targetPlayer:GetCivilizationType()].ShortDescription)
+
+    if not myTeam:CanDeclareWar(targetTeam) then
+      return { Success = false, TargetCiv = targetCivName, Message = "Cannot declare war (peace treaty or other restriction)" }
+    end
+
+    myTeam:DeclareWar(targetTeam)
+
+    return {
+      Success = true,
+      TargetCiv = targetCivName,
+      Message = "War declared on " .. targetCivName
+    }
+  `;
+
+  async execute(args: z.infer<typeof this.inputSchema>): Promise<z.infer<typeof this.outputSchema>> {
+    return await super.call(args.PlayerID, args.TargetPlayerID);
+  }
+}
+
+export default function createDeclareWarTool() {
+  return new DeclareWarTool();
+}

--- a/mcp-server/src/tools/actions/denounce.ts
+++ b/mcp-server/src/tools/actions/denounce.ts
@@ -1,0 +1,70 @@
+/**
+ * Denounce tool for AI player control
+ */
+
+import { LuaFunctionTool } from "../abstract/lua-function.js";
+import * as z from "zod";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { MaxMajorCivs } from "../../knowledge/schema/base.js";
+
+const DenounceResultSchema = z.object({
+  Success: z.boolean(),
+  TargetCiv: z.string().optional(),
+  Message: z.string().optional(),
+});
+
+type DenounceResultType = z.infer<typeof DenounceResultSchema>;
+
+class DenounceTool extends LuaFunctionTool<DenounceResultType> {
+  readonly name = "denounce";
+
+  readonly description = `Publicly denounce another civilization.
+
+Denouncing damages your relationship and signals hostility to other civs.
+Can only denounce once per civilization every 50 turns.`;
+
+  inputSchema = z.object({
+    PlayerID: z.number().min(0).max(MaxMajorCivs - 1)
+      .describe("Your player ID"),
+    TargetPlayerID: z.number().min(0).max(MaxMajorCivs - 1)
+      .describe("Target civilization's player ID"),
+  });
+
+  protected resultSchema = DenounceResultSchema;
+  protected arguments = ["playerID", "targetPlayerID"];
+
+  readonly annotations: ToolAnnotations = {
+    readOnlyHint: false
+  };
+
+  protected script = `
+    local player = Players[playerID]
+    local targetPlayer = Players[targetPlayerID]
+
+    if not player or not targetPlayer then
+      return { Success = false, Message = "Invalid player ID" }
+    end
+
+    local targetCivName = Locale.ConvertTextKey(GameInfo.Civilizations[targetPlayer:GetCivilizationType()].ShortDescription)
+
+    if not player:CanDenounce(targetPlayerID) then
+      return { Success = false, TargetCiv = targetCivName, Message = "Cannot denounce (cooldown or other restriction)" }
+    end
+
+    player:Denounce(targetPlayerID)
+
+    return {
+      Success = true,
+      TargetCiv = targetCivName,
+      Message = "Denounced " .. targetCivName
+    }
+  `;
+
+  async execute(args: z.infer<typeof this.inputSchema>): Promise<z.infer<typeof this.outputSchema>> {
+    return await super.call(args.PlayerID, args.TargetPlayerID);
+  }
+}
+
+export default function createDenounceTool() {
+  return new DenounceTool();
+}

--- a/mcp-server/src/tools/actions/found-city.ts
+++ b/mcp-server/src/tools/actions/found-city.ts
@@ -1,0 +1,106 @@
+/**
+ * City founding tool for AI player control
+ * Kali ❤️‍🔥 [Visionary]: The birth of a new city!
+ * Athena 🦉 [Reviewer]: MISSION_FOUND - settler is consumed
+ */
+
+import { LuaFunctionTool } from "../abstract/lua-function.js";
+import * as z from "zod";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { MaxMajorCivs } from "../../knowledge/schema/base.js";
+
+const FoundCityResultSchema = z.object({
+  Success: z.boolean(),
+  SettlerID: z.number(),
+  X: z.number(),
+  Y: z.number(),
+  CityName: z.string().optional(),
+  Message: z.string().optional(),
+});
+
+type FoundCityResultType = z.infer<typeof FoundCityResultSchema>;
+
+class FoundCityTool extends LuaFunctionTool<FoundCityResultType> {
+  readonly name = "found-city";
+
+  readonly description = `Found a new city with a settler.
+
+The settler must be on a valid tile (not too close to other cities,
+not on water, etc.). The settler is consumed when the city is founded.
+Use get-map-region to find good city locations.`;
+
+  inputSchema = z.object({
+    PlayerID: z.number().min(0).max(MaxMajorCivs - 1)
+      .describe("Player ID (owner of the settler)"),
+    UnitID: z.number()
+      .describe("The settler unit's ID"),
+  });
+
+  protected resultSchema = FoundCityResultSchema;
+  protected arguments = ["playerID", "unitID"];
+
+  readonly annotations: ToolAnnotations = {
+    readOnlyHint: false
+  };
+
+  // Nemesis 💀 [Security]: Verify settler can actually found here
+  // Kali ❤️‍🔥 [User Advocate]: Return the new city name for feedback
+  protected script = `
+    local player = Players[playerID]
+    if not player then
+      return { Success = false, SettlerID = unitID, X = -1, Y = -1, Message = "Invalid player" }
+    end
+
+    local unit = player:GetUnitByID(unitID)
+    if not unit then
+      return { Success = false, SettlerID = unitID, X = -1, Y = -1, Message = "Unit not found" }
+    end
+
+    local x = unit:GetX()
+    local y = unit:GetY()
+
+    -- Check if this is a settler-type unit
+    if not unit:IsFound() then
+      return { Success = false, SettlerID = unitID, X = x, Y = y, Message = "Unit cannot found cities" }
+    end
+
+    -- Check if we can found here
+    if not unit:CanFound(unit:GetPlot()) then
+      return { Success = false, SettlerID = unitID, X = x, Y = y, Message = "Cannot found city at this location" }
+    end
+
+    -- Get city count before founding
+    local cityCountBefore = player:GetNumCities()
+
+    -- Found the city
+    unit:PushMission(MissionTypes.MISSION_FOUND, -1, -1, 0, false, false, MissionAITypes.MISSIONAI_FOUND, nil, nil)
+
+    -- Check if city was founded
+    local cityCountAfter = player:GetNumCities()
+    if cityCountAfter <= cityCountBefore then
+      return { Success = false, SettlerID = unitID, X = x, Y = y, Message = "City founding failed" }
+    end
+
+    -- Find the new city (should be at this location)
+    local plot = Map.GetPlot(x, y)
+    local newCity = plot:GetPlotCity()
+    local cityName = newCity and newCity:GetName() or "Unknown"
+
+    return {
+      Success = true,
+      SettlerID = unitID,
+      X = x,
+      Y = y,
+      CityName = cityName,
+      Message = "Founded " .. cityName
+    }
+  `;
+
+  async execute(args: z.infer<typeof this.inputSchema>): Promise<z.infer<typeof this.outputSchema>> {
+    return await super.call(args.PlayerID, args.UnitID);
+  }
+}
+
+export default function createFoundCityTool() {
+  return new FoundCityTool();
+}

--- a/mcp-server/src/tools/actions/make-peace.ts
+++ b/mcp-server/src/tools/actions/make-peace.ts
@@ -1,0 +1,77 @@
+/**
+ * Make peace tool for AI player control
+ */
+
+import { LuaFunctionTool } from "../abstract/lua-function.js";
+import * as z from "zod";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { MaxMajorCivs } from "../../knowledge/schema/base.js";
+
+const MakePeaceResultSchema = z.object({
+  Success: z.boolean(),
+  TargetCiv: z.string().optional(),
+  Message: z.string().optional(),
+});
+
+type MakePeaceResultType = z.infer<typeof MakePeaceResultSchema>;
+
+class MakePeaceTool extends LuaFunctionTool<MakePeaceResultType> {
+  readonly name = "make-peace";
+
+  readonly description = `Make peace with a civilization you are at war with.
+
+Note: In normal gameplay, peace requires negotiation. This forces peace.
+There may be a minimum war duration before peace is possible.`;
+
+  inputSchema = z.object({
+    PlayerID: z.number().min(0).max(MaxMajorCivs - 1)
+      .describe("Your player ID"),
+    TargetPlayerID: z.number().min(0).max(MaxMajorCivs - 1)
+      .describe("Target civilization's player ID"),
+  });
+
+  protected resultSchema = MakePeaceResultSchema;
+  protected arguments = ["playerID", "targetPlayerID"];
+
+  readonly annotations: ToolAnnotations = {
+    readOnlyHint: false
+  };
+
+  protected script = `
+    local player = Players[playerID]
+    local targetPlayer = Players[targetPlayerID]
+
+    if not player or not targetPlayer then
+      return { Success = false, Message = "Invalid player ID" }
+    end
+
+    local myTeam = Teams[player:GetTeam()]
+    local targetTeam = targetPlayer:GetTeam()
+    local targetCivName = Locale.ConvertTextKey(GameInfo.Civilizations[targetPlayer:GetCivilizationType()].ShortDescription)
+
+    if not myTeam:IsAtWar(targetTeam) then
+      return { Success = false, TargetCiv = targetCivName, Message = "Not at war with " .. targetCivName }
+    end
+
+    local turnsLocked = myTeam:GetNumTurnsLockedIntoWar(targetTeam)
+    if turnsLocked > 0 then
+      return { Success = false, TargetCiv = targetCivName, Message = "Locked into war for " .. turnsLocked .. " more turns" }
+    end
+
+    myTeam:MakePeace(targetTeam)
+
+    return {
+      Success = true,
+      TargetCiv = targetCivName,
+      Message = "Peace made with " .. targetCivName
+    }
+  `;
+
+  async execute(args: z.infer<typeof this.inputSchema>): Promise<z.infer<typeof this.outputSchema>> {
+    return await super.call(args.PlayerID, args.TargetPlayerID);
+  }
+}
+
+export default function createMakePeaceTool() {
+  return new MakePeaceTool();
+}

--- a/mcp-server/src/tools/actions/move-spy.ts
+++ b/mcp-server/src/tools/actions/move-spy.ts
@@ -1,0 +1,103 @@
+/**
+ * Move spy tool for AI player control
+ */
+
+import { LuaFunctionTool } from "../abstract/lua-function.js";
+import * as z from "zod";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { MaxMajorCivs } from "../../knowledge/schema/base.js";
+
+const MoveSpyResultSchema = z.object({
+  Success: z.boolean(),
+  SpyName: z.string().optional(),
+  DestinationCity: z.string().optional(),
+  Message: z.string().optional(),
+});
+
+type MoveSpyResultType = z.infer<typeof MoveSpyResultSchema>;
+
+class MoveSpyTool extends LuaFunctionTool<MoveSpyResultType> {
+  readonly name = "move-spy";
+
+  readonly description = `Move a spy to a city for espionage.
+
+Use get-espionage to see your spies and available cities.
+Spies can be sent to enemy cities (steal tech, gather intel),
+city-states (rig elections, coup), or your own cities (counterintelligence).`;
+
+  inputSchema = z.object({
+    PlayerID: z.number().min(0).max(MaxMajorCivs - 1)
+      .describe("Your player ID"),
+    SpyIndex: z.number().min(0)
+      .describe("Index of the spy (0-based, from get-espionage)"),
+    TargetCityOwnerID: z.number()
+      .describe("Player ID of the city owner"),
+    TargetCityID: z.number()
+      .describe("Target city's ID"),
+  });
+
+  protected resultSchema = MoveSpyResultSchema;
+  protected arguments = ["playerID", "spyIndex", "targetOwnerID", "targetCityID"];
+
+  readonly annotations: ToolAnnotations = {
+    readOnlyHint: false
+  };
+
+  protected script = `
+    local player = Players[playerID]
+    if not player then
+      return { Success = false, Message = "Invalid player" }
+    end
+
+    local espionage = player:GetEspionage()
+    if not espionage then
+      return { Success = false, Message = "Espionage not available" }
+    end
+
+    local numSpies = espionage:GetNumSpies()
+    if spyIndex >= numSpies then
+      return { Success = false, Message = "Invalid spy index" }
+    end
+
+    local spyName = espionage:GetSpyName(spyIndex)
+
+    local targetPlayer = Players[targetOwnerID]
+    if not targetPlayer then
+      return { Success = false, SpyName = spyName, Message = "Invalid target owner" }
+    end
+
+    local targetCity = targetPlayer:GetCityByID(targetCityID)
+    if not targetCity then
+      return { Success = false, SpyName = spyName, Message = "Target city not found" }
+    end
+
+    local cityName = targetCity:GetName()
+
+    -- Move the spy
+    local success = espionage:MoveSpyTo(spyIndex, targetCity)
+
+    if success then
+      return {
+        Success = true,
+        SpyName = spyName,
+        DestinationCity = cityName,
+        Message = spyName .. " sent to " .. cityName
+      }
+    else
+      return {
+        Success = false,
+        SpyName = spyName,
+        DestinationCity = cityName,
+        Message = "Failed to move spy to " .. cityName
+      }
+    end
+  `;
+
+  async execute(args: z.infer<typeof this.inputSchema>): Promise<z.infer<typeof this.outputSchema>> {
+    return await super.call(args.PlayerID, args.SpyIndex, args.TargetCityOwnerID, args.TargetCityID);
+  }
+}
+
+export default function createMoveSpyTool() {
+  return new MoveSpyTool();
+}

--- a/mcp-server/src/tools/actions/move-unit.ts
+++ b/mcp-server/src/tools/actions/move-unit.ts
@@ -1,0 +1,108 @@
+/**
+ * Direct unit movement tool for AI player control
+ * Kali ❤️‍🔥 [Visionary]: This is it - the foundation of direct play
+ * Athena 🦉 [Reviewer]: Structured tool > raw Lua for reliability
+ */
+
+import { LuaFunctionTool } from "../abstract/lua-function.js";
+import * as z from "zod";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { MaxMajorCivs } from "../../knowledge/schema/base.js";
+
+const MoveUnitResultSchema = z.object({
+  Success: z.boolean(),
+  UnitID: z.number(),
+  FromX: z.number(),
+  FromY: z.number(),
+  ToX: z.number(),
+  ToY: z.number(),
+  MovesRemaining: z.number(),
+  Message: z.string().optional(),
+});
+
+type MoveUnitResultType = z.infer<typeof MoveUnitResultSchema>;
+
+class MoveUnitTool extends LuaFunctionTool<MoveUnitResultType> {
+  readonly name = "move-unit";
+
+  readonly description = `Move a unit to a target tile.
+
+The unit will path toward the destination using available movement points.
+If the destination is unreachable this turn, the unit moves as far as possible.
+Use get-map-region first to understand terrain and valid destinations.`;
+
+  inputSchema = z.object({
+    PlayerID: z.number().min(0).max(MaxMajorCivs - 1)
+      .describe("Player ID (owner of the unit)"),
+    UnitID: z.number()
+      .describe("The unit's ID (from summarize-units or get-map-region)"),
+    TargetX: z.number().min(0)
+      .describe("Target tile X coordinate"),
+    TargetY: z.number().min(0)
+      .describe("Target tile Y coordinate"),
+  });
+
+  protected resultSchema = MoveUnitResultSchema;
+  protected arguments = ["playerID", "unitID", "targetX", "targetY"];
+
+  readonly annotations: ToolAnnotations = {
+    readOnlyHint: false
+  };
+
+  // Kali ❤️‍🔥 [User Advocate]: Clear feedback on what happened
+  // Nemesis 💀 [Security]: Verify unit ownership before moving
+  protected script = `
+    local player = Players[playerID]
+    if not player then
+      return { Success = false, UnitID = unitID, FromX = -1, FromY = -1, ToX = targetX, ToY = targetY, MovesRemaining = 0, Message = "Invalid player" }
+    end
+
+    local unit = player:GetUnitByID(unitID)
+    if not unit then
+      return { Success = false, UnitID = unitID, FromX = -1, FromY = -1, ToX = targetX, ToY = targetY, MovesRemaining = 0, Message = "Unit not found" }
+    end
+
+    local fromX = unit:GetX()
+    local fromY = unit:GetY()
+    local movesBefore = unit:MovesLeft()
+
+    -- Push the move mission
+    unit:PushMission(MissionTypes.MISSION_MOVE_TO, targetX, targetY, 0, false, false, MissionAITypes.NO_MISSIONAI, nil, nil)
+
+    local movesAfter = unit:MovesLeft()
+    local newX = unit:GetX()
+    local newY = unit:GetY()
+
+    -- Check if we actually moved
+    local moved = (newX ~= fromX or newY ~= fromY)
+    local reachedTarget = (newX == targetX and newY == targetY)
+
+    local message = nil
+    if reachedTarget then
+      message = "Reached destination"
+    elseif moved then
+      message = "Moved toward destination (not enough movement to reach)"
+    else
+      message = "Could not move (blocked or no path)"
+    end
+
+    return {
+      Success = moved,
+      UnitID = unitID,
+      FromX = fromX,
+      FromY = fromY,
+      ToX = newX,
+      ToY = newY,
+      MovesRemaining = movesAfter,
+      Message = message
+    }
+  `;
+
+  async execute(args: z.infer<typeof this.inputSchema>): Promise<z.infer<typeof this.outputSchema>> {
+    return await super.call(args.PlayerID, args.UnitID, args.TargetX, args.TargetY);
+  }
+}
+
+export default function createMoveUnitTool() {
+  return new MoveUnitTool();
+}

--- a/mcp-server/src/tools/actions/ranged-attack.ts
+++ b/mcp-server/src/tools/actions/ranged-attack.ts
@@ -1,0 +1,118 @@
+/**
+ * Ranged attack tool for AI player control
+ * Kali ❤️‍🔥 [Visionary]: Archers, crossbows, artillery - strike from afar
+ * Athena 🦉 [Reviewer]: Ranged units don't take counter-damage (usually)
+ */
+
+import { LuaFunctionTool } from "../abstract/lua-function.js";
+import * as z from "zod";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { MaxMajorCivs } from "../../knowledge/schema/base.js";
+
+const RangedAttackResultSchema = z.object({
+  Success: z.boolean(),
+  AttackerID: z.number(),
+  TargetX: z.number(),
+  TargetY: z.number(),
+  DamageDealt: z.number().optional(),
+  TargetKilled: z.boolean().optional(),
+  Message: z.string().optional(),
+});
+
+type RangedAttackResultType = z.infer<typeof RangedAttackResultSchema>;
+
+class RangedAttackTool extends LuaFunctionTool<RangedAttackResultType> {
+  readonly name = "ranged-attack";
+
+  readonly description = `Execute a ranged attack against a target tile.
+
+The unit fires at the target without moving. Ranged attacks typically
+don't trigger counter-attacks. The target must be within range.
+Use get-combat-preview to check range and expected damage.`;
+
+  inputSchema = z.object({
+    PlayerID: z.number().min(0).max(MaxMajorCivs - 1)
+      .describe("Player ID (owner of the attacking unit)"),
+    UnitID: z.number()
+      .describe("The ranged unit's ID"),
+    TargetX: z.number().min(0)
+      .describe("Target tile X coordinate"),
+    TargetY: z.number().min(0)
+      .describe("Target tile Y coordinate"),
+  });
+
+  protected resultSchema = RangedAttackResultSchema;
+  protected arguments = ["playerID", "unitID", "targetX", "targetY"];
+
+  readonly annotations: ToolAnnotations = {
+    readOnlyHint: false
+  };
+
+  // Vesta 🔥 [Builder]: MISSION_RANGE_ATTACK is the key
+  protected script = `
+    local player = Players[playerID]
+    if not player then
+      return { Success = false, AttackerID = unitID, TargetX = targetX, TargetY = targetY, Message = "Invalid player" }
+    end
+
+    local unit = player:GetUnitByID(unitID)
+    if not unit then
+      return { Success = false, AttackerID = unitID, TargetX = targetX, TargetY = targetY, Message = "Unit not found" }
+    end
+
+    -- Check if unit can do ranged attacks
+    if not unit:IsRanged() then
+      return { Success = false, AttackerID = unitID, TargetX = targetX, TargetY = targetY, Message = "Unit is not ranged" }
+    end
+
+    if not unit:CanRangeStrikeAt(targetX, targetY) then
+      return { Success = false, AttackerID = unitID, TargetX = targetX, TargetY = targetY, Message = "Target out of range or invalid" }
+    end
+
+    local targetPlot = Map.GetPlot(targetX, targetY)
+    if not targetPlot then
+      return { Success = false, AttackerID = unitID, TargetX = targetX, TargetY = targetY, Message = "Invalid target coordinates" }
+    end
+
+    -- Get target info before attack
+    local defender = targetPlot:GetUnit(0)
+    local defenderHPBefore = defender and defender:GetCurrHitPoints() or 0
+    local targetCity = targetPlot:GetPlotCity()
+    local cityHPBefore = targetCity and targetCity:GetDamage() or 0
+
+    -- Execute the ranged attack
+    unit:PushMission(MissionTypes.MISSION_RANGE_ATTACK, targetX, targetY, 0, false, false, MissionAITypes.NO_MISSIONAI, nil, nil)
+
+    -- Check results
+    local damageDealt = 0
+    local targetKilled = false
+
+    if defender then
+      local defenderAlive = defender.IsAlive and defender:IsAlive() or false
+      local defenderHPAfter = defenderAlive and defender:GetCurrHitPoints() or 0
+      damageDealt = defenderHPBefore - defenderHPAfter
+      targetKilled = not defenderAlive
+    elseif targetCity then
+      local cityHPAfter = targetCity:GetDamage()
+      damageDealt = cityHPAfter - cityHPBefore  -- Damage increases for cities
+    end
+
+    return {
+      Success = true,
+      AttackerID = unitID,
+      TargetX = targetX,
+      TargetY = targetY,
+      DamageDealt = damageDealt,
+      TargetKilled = targetKilled,
+      Message = "Ranged attack executed"
+    }
+  `;
+
+  async execute(args: z.infer<typeof this.inputSchema>): Promise<z.infer<typeof this.outputSchema>> {
+    return await super.call(args.PlayerID, args.UnitID, args.TargetX, args.TargetY);
+  }
+}
+
+export default function createRangedAttackTool() {
+  return new RangedAttackTool();
+}

--- a/mcp-server/src/tools/actions/sell-building.ts
+++ b/mcp-server/src/tools/actions/sell-building.ts
@@ -1,0 +1,93 @@
+/**
+ * Sell building tool for AI player control
+ */
+
+import { LuaFunctionTool } from "../abstract/lua-function.js";
+import * as z from "zod";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { MaxMajorCivs } from "../../knowledge/schema/base.js";
+
+const SellBuildingResultSchema = z.object({
+  Success: z.boolean(),
+  CityName: z.string().optional(),
+  BuildingName: z.string().optional(),
+  GoldReceived: z.number().optional(),
+  Message: z.string().optional(),
+});
+
+type SellBuildingResultType = z.infer<typeof SellBuildingResultSchema>;
+
+class SellBuildingTool extends LuaFunctionTool<SellBuildingResultType> {
+  readonly name = "sell-building";
+
+  readonly description = `Sell a building in a city for gold.
+
+Not all buildings can be sold (wonders, etc. cannot).
+Use get-cities to see which buildings exist in each city.`;
+
+  inputSchema = z.object({
+    PlayerID: z.number().min(0).max(MaxMajorCivs - 1)
+      .describe("Player ID (owner of the city)"),
+    CityID: z.number()
+      .describe("The city's ID"),
+    BuildingTypeID: z.number()
+      .describe("Building type ID to sell"),
+  });
+
+  protected resultSchema = SellBuildingResultSchema;
+  protected arguments = ["playerID", "cityID", "buildingTypeID"];
+
+  readonly annotations: ToolAnnotations = {
+    readOnlyHint: false
+  };
+
+  protected script = `
+    local player = Players[playerID]
+    if not player then
+      return { Success = false, Message = "Invalid player" }
+    end
+
+    local city = player:GetCityByID(cityID)
+    if not city then
+      return { Success = false, Message = "City not found" }
+    end
+
+    local cityName = city:GetName()
+    local buildingInfo = GameInfo.Buildings[buildingTypeID]
+
+    if not buildingInfo then
+      return { Success = false, CityName = cityName, Message = "Invalid building type" }
+    end
+
+    local buildingName = Locale.ConvertTextKey(buildingInfo.Description)
+
+    if not city:IsHasBuilding(buildingTypeID) then
+      return { Success = false, CityName = cityName, BuildingName = buildingName, Message = "City does not have this building" }
+    end
+
+    if not city:IsBuildingSellable(buildingTypeID) then
+      return { Success = false, CityName = cityName, BuildingName = buildingName, Message = "This building cannot be sold" }
+    end
+
+    local goldValue = city:GetSellBuildingRefund(buildingTypeID)
+
+    city:SetNumRealBuilding(buildingTypeID, 0)
+    player:ChangeGold(goldValue)
+
+    return {
+      Success = true,
+      CityName = cityName,
+      BuildingName = buildingName,
+      GoldReceived = goldValue,
+      Message = "Sold " .. buildingName .. " for " .. goldValue .. " gold"
+    }
+  `;
+
+  async execute(args: z.infer<typeof this.inputSchema>): Promise<z.infer<typeof this.outputSchema>> {
+    return await super.call(args.PlayerID, args.CityID, args.BuildingTypeID);
+  }
+}
+
+export default function createSellBuildingTool() {
+  return new SellBuildingTool();
+}

--- a/mcp-server/src/tools/actions/set-city-production.ts
+++ b/mcp-server/src/tools/actions/set-city-production.ts
@@ -1,0 +1,125 @@
+/**
+ * City production tool for AI player control
+ * Kali ❤️‍🔥 [Visionary]: Build the empire, one production at a time
+ * Athena 🦉 [Reviewer]: ORDER_TRAIN for units, ORDER_CONSTRUCT for buildings
+ */
+
+import { LuaFunctionTool } from "../abstract/lua-function.js";
+import * as z from "zod";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { MaxMajorCivs } from "../../knowledge/schema/base.js";
+
+const SetProductionResultSchema = z.object({
+  Success: z.boolean(),
+  CityName: z.string().optional(),
+  ProductionType: z.string().optional(),
+  ProductionName: z.string().optional(),
+  TurnsToComplete: z.number().optional(),
+  Message: z.string().optional(),
+});
+
+type SetProductionResultType = z.infer<typeof SetProductionResultSchema>;
+
+class SetCityProductionTool extends LuaFunctionTool<SetProductionResultType> {
+  readonly name = "set-city-production";
+
+  readonly description = `Set what a city is producing.
+
+Specify either a unit type ID or building type ID. Use get-cities to see
+what each city can build. The city will immediately switch production.`;
+
+  inputSchema = z.object({
+    PlayerID: z.number().min(0).max(MaxMajorCivs - 1)
+      .describe("Player ID (owner of the city)"),
+    CityID: z.number()
+      .describe("The city's ID (from get-cities)"),
+    UnitTypeID: z.number().optional()
+      .describe("Unit type ID to train (mutually exclusive with BuildingTypeID)"),
+    BuildingTypeID: z.number().optional()
+      .describe("Building type ID to construct (mutually exclusive with UnitTypeID)"),
+  });
+
+  protected resultSchema = SetProductionResultSchema;
+  protected arguments = ["playerID", "cityID", "unitTypeID", "buildingTypeID"];
+
+  readonly annotations: ToolAnnotations = {
+    readOnlyHint: false
+  };
+
+  // Vesta 🔥 [Builder]: pushOrder is the key function
+  // Nemesis 💀 [Security]: Validate the city can actually build this
+  protected script = `
+    local player = Players[playerID]
+    if not player then
+      return { Success = false, Message = "Invalid player" }
+    end
+
+    local city = player:GetCityByID(cityID)
+    if not city then
+      return { Success = false, Message = "City not found" }
+    end
+
+    local cityName = city:GetName()
+
+    -- Determine what to build
+    if unitTypeID and unitTypeID >= 0 then
+      -- Check if city can train this unit
+      if not city:CanTrain(unitTypeID) then
+        return { Success = false, CityName = cityName, Message = "City cannot train this unit" }
+      end
+
+      -- Clear queue and push new order
+      city:ClearOrderQueue()
+      city:PushOrder(OrderTypes.ORDER_TRAIN, unitTypeID, -1, false, false, false, false)
+
+      local unitInfo = GameInfo.Units[unitTypeID]
+      local unitName = unitInfo and Locale.ConvertTextKey(unitInfo.Description) or "Unknown Unit"
+      local turns = city:GetUnitProductionTurnsLeft(unitTypeID, 0)
+
+      return {
+        Success = true,
+        CityName = cityName,
+        ProductionType = "Unit",
+        ProductionName = unitName,
+        TurnsToComplete = turns,
+        Message = "Now training " .. unitName
+      }
+
+    elseif buildingTypeID and buildingTypeID >= 0 then
+      -- Check if city can construct this building
+      if not city:CanConstruct(buildingTypeID) then
+        return { Success = false, CityName = cityName, Message = "City cannot construct this building" }
+      end
+
+      -- Clear queue and push new order
+      city:ClearOrderQueue()
+      city:PushOrder(OrderTypes.ORDER_CONSTRUCT, buildingTypeID, -1, false, false, false, false)
+
+      local buildingInfo = GameInfo.Buildings[buildingTypeID]
+      local buildingName = buildingInfo and Locale.ConvertTextKey(buildingInfo.Description) or "Unknown Building"
+      local turns = city:GetBuildingProductionTurnsLeft(buildingTypeID, 0)
+
+      return {
+        Success = true,
+        CityName = cityName,
+        ProductionType = "Building",
+        ProductionName = buildingName,
+        TurnsToComplete = turns,
+        Message = "Now constructing " .. buildingName
+      }
+
+    else
+      return { Success = false, CityName = cityName, Message = "Must specify either UnitTypeID or BuildingTypeID" }
+    end
+  `;
+
+  async execute(args: z.infer<typeof this.inputSchema>): Promise<z.infer<typeof this.outputSchema>> {
+    const unitTypeID = args.UnitTypeID ?? -1;
+    const buildingTypeID = args.BuildingTypeID ?? -1;
+    return await super.call(args.PlayerID, args.CityID, unitTypeID, buildingTypeID);
+  }
+}
+
+export default function createSetCityProductionTool() {
+  return new SetCityProductionTool();
+}

--- a/mcp-server/src/tools/actions/spread-religion.ts
+++ b/mcp-server/src/tools/actions/spread-religion.ts
@@ -1,0 +1,96 @@
+/**
+ * Spread religion tool for missionaries and prophets
+ */
+
+import { LuaFunctionTool } from "../abstract/lua-function.js";
+import * as z from "zod";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { MaxMajorCivs } from "../../knowledge/schema/base.js";
+
+const SpreadReligionResultSchema = z.object({
+  Success: z.boolean(),
+  UnitID: z.number(),
+  CityName: z.string().optional(),
+  SpreadStrength: z.number().optional(),
+  ChargesRemaining: z.number().optional(),
+  Message: z.string().optional(),
+});
+
+type SpreadReligionResultType = z.infer<typeof SpreadReligionResultSchema>;
+
+class SpreadReligionTool extends LuaFunctionTool<SpreadReligionResultType> {
+  readonly name = "spread-religion";
+
+  readonly description = `Use a missionary or prophet to spread religion to a city.
+
+The unit must be in or adjacent to the target city.
+Missionaries have limited charges. Great Prophets are consumed.`;
+
+  inputSchema = z.object({
+    PlayerID: z.number().min(0).max(MaxMajorCivs - 1)
+      .describe("Player ID (owner of the religious unit)"),
+    UnitID: z.number()
+      .describe("The missionary or prophet unit's ID"),
+  });
+
+  protected resultSchema = SpreadReligionResultSchema;
+  protected arguments = ["playerID", "unitID"];
+
+  readonly annotations: ToolAnnotations = {
+    readOnlyHint: false
+  };
+
+  protected script = `
+    local player = Players[playerID]
+    if not player then
+      return { Success = false, UnitID = unitID, Message = "Invalid player" }
+    end
+
+    local unit = player:GetUnitByID(unitID)
+    if not unit then
+      return { Success = false, UnitID = unitID, Message = "Unit not found" }
+    end
+
+    local plot = unit:GetPlot()
+    if not unit:CanSpreadReligion(plot) then
+      return { Success = false, UnitID = unitID, Message = "Cannot spread religion here" }
+    end
+
+    local city = plot:GetPlotCity()
+    if not city then
+      -- Check adjacent plots for city
+      for i = 0, 5 do
+        local adjPlot = Map.PlotDirection(plot:GetX(), plot:GetY(), i)
+        if adjPlot then
+          city = adjPlot:GetPlotCity()
+          if city then break end
+        end
+      end
+    end
+
+    local cityName = city and city:GetName() or "Unknown"
+    local spreadStrength = unit:GetReligionSpreads()
+    local chargesBefore = unit:GetSpreadsLeft and unit:GetSpreadsLeft() or 1
+
+    unit:DoSpreadReligion()
+
+    local chargesAfter = unit:GetSpreadsLeft and unit:GetSpreadsLeft() or 0
+
+    return {
+      Success = true,
+      UnitID = unitID,
+      CityName = cityName,
+      SpreadStrength = spreadStrength,
+      ChargesRemaining = chargesAfter,
+      Message = "Spread religion to " .. cityName
+    }
+  `;
+
+  async execute(args: z.infer<typeof this.inputSchema>): Promise<z.infer<typeof this.outputSchema>> {
+    return await super.call(args.PlayerID, args.UnitID);
+  }
+}
+
+export default function createSpreadReligionTool() {
+  return new SpreadReligionTool();
+}

--- a/mcp-server/src/tools/actions/unit-command.ts
+++ b/mcp-server/src/tools/actions/unit-command.ts
@@ -1,0 +1,123 @@
+/**
+ * General unit command tool for fortify, sleep, pillage, etc.
+ */
+
+import { LuaFunctionTool } from "../abstract/lua-function.js";
+import * as z from "zod";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { MaxMajorCivs } from "../../knowledge/schema/base.js";
+
+const UnitCommandResultSchema = z.object({
+  Success: z.boolean(),
+  UnitID: z.number(),
+  Command: z.string(),
+  Message: z.string().optional(),
+});
+
+type UnitCommandResultType = z.infer<typeof UnitCommandResultSchema>;
+
+class UnitCommandTool extends LuaFunctionTool<UnitCommandResultType> {
+  readonly name = "unit-command";
+
+  readonly description = `Execute a unit command like fortify, sleep, pillage, skip turn, etc.
+
+Available commands:
+- FORTIFY: Unit fortifies and gains defensive bonus over time
+- SLEEP: Unit sleeps until enemy approaches
+- ALERT: Unit wakes when enemy is spotted
+- SKIP: Skip this unit's turn
+- PILLAGE: Destroy improvement on current tile (must be enemy territory)
+- WAKE: Wake a sleeping/fortified unit
+- DELETE: Delete the unit (irreversible)
+- HEAL: Fortify until healed`;
+
+  inputSchema = z.object({
+    PlayerID: z.number().min(0).max(MaxMajorCivs - 1)
+      .describe("Player ID (owner of the unit)"),
+    UnitID: z.number()
+      .describe("The unit's ID"),
+    Command: z.enum(["FORTIFY", "SLEEP", "ALERT", "SKIP", "PILLAGE", "WAKE", "DELETE", "HEAL"])
+      .describe("The command to execute"),
+  });
+
+  protected resultSchema = UnitCommandResultSchema;
+  protected arguments = ["playerID", "unitID", "command"];
+
+  readonly annotations: ToolAnnotations = {
+    readOnlyHint: false
+  };
+
+  protected script = `
+    local player = Players[playerID]
+    if not player then
+      return { Success = false, UnitID = unitID, Command = command, Message = "Invalid player" }
+    end
+
+    local unit = player:GetUnitByID(unitID)
+    if not unit then
+      return { Success = false, UnitID = unitID, Command = command, Message = "Unit not found" }
+    end
+
+    local success = false
+    local message = ""
+
+    if command == "FORTIFY" then
+      if unit:CanFortify(unit:GetPlot()) then
+        unit:PushMission(MissionTypes.MISSION_FORTIFY)
+        success = true
+        message = "Unit fortifying"
+      else
+        message = "Unit cannot fortify here"
+      end
+    elseif command == "SLEEP" then
+      unit:PushMission(MissionTypes.MISSION_SLEEP)
+      success = true
+      message = "Unit sleeping"
+    elseif command == "ALERT" then
+      unit:PushMission(MissionTypes.MISSION_ALERT)
+      success = true
+      message = "Unit on alert"
+    elseif command == "SKIP" then
+      unit:PushMission(MissionTypes.MISSION_SKIP)
+      success = true
+      message = "Turn skipped"
+    elseif command == "PILLAGE" then
+      if unit:CanPillage(unit:GetPlot()) then
+        unit:PushMission(MissionTypes.MISSION_PILLAGE)
+        success = true
+        message = "Pillaging improvement"
+      else
+        message = "Cannot pillage here"
+      end
+    elseif command == "WAKE" then
+      unit:PushMission(MissionTypes.MISSION_WAKE)
+      success = true
+      message = "Unit woken"
+    elseif command == "DELETE" then
+      unit:Kill(true)
+      success = true
+      message = "Unit deleted"
+    elseif command == "HEAL" then
+      unit:PushMission(MissionTypes.MISSION_HEAL)
+      success = true
+      message = "Healing until full"
+    else
+      message = "Unknown command"
+    end
+
+    return {
+      Success = success,
+      UnitID = unitID,
+      Command = command,
+      Message = message
+    }
+  `;
+
+  async execute(args: z.infer<typeof this.inputSchema>): Promise<z.infer<typeof this.outputSchema>> {
+    return await super.call(args.PlayerID, args.UnitID, args.Command);
+  }
+}
+
+export default function createUnitCommandTool() {
+  return new UnitCommandTool();
+}

--- a/mcp-server/src/tools/actions/upgrade-unit.ts
+++ b/mcp-server/src/tools/actions/upgrade-unit.ts
@@ -1,0 +1,94 @@
+/**
+ * Upgrade unit tool for AI player control
+ */
+
+import { LuaFunctionTool } from "../abstract/lua-function.js";
+import * as z from "zod";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { MaxMajorCivs } from "../../knowledge/schema/base.js";
+
+const UpgradeUnitResultSchema = z.object({
+  Success: z.boolean(),
+  UnitID: z.number(),
+  OldType: z.string().optional(),
+  NewType: z.string().optional(),
+  GoldCost: z.number().optional(),
+  Message: z.string().optional(),
+});
+
+type UpgradeUnitResultType = z.infer<typeof UpgradeUnitResultSchema>;
+
+class UpgradeUnitTool extends LuaFunctionTool<UpgradeUnitResultType> {
+  readonly name = "upgrade-unit";
+
+  readonly description = `Upgrade a unit to its next available type.
+
+The unit must be in friendly territory and you must have enough gold.
+Use summarize-units to see which units can upgrade and the cost.`;
+
+  inputSchema = z.object({
+    PlayerID: z.number().min(0).max(MaxMajorCivs - 1)
+      .describe("Player ID (owner of the unit)"),
+    UnitID: z.number()
+      .describe("The unit's ID"),
+  });
+
+  protected resultSchema = UpgradeUnitResultSchema;
+  protected arguments = ["playerID", "unitID"];
+
+  readonly annotations: ToolAnnotations = {
+    readOnlyHint: false
+  };
+
+  protected script = `
+    local player = Players[playerID]
+    if not player then
+      return { Success = false, UnitID = unitID, Message = "Invalid player" }
+    end
+
+    local unit = player:GetUnitByID(unitID)
+    if not unit then
+      return { Success = false, UnitID = unitID, Message = "Unit not found" }
+    end
+
+    local oldType = Locale.ConvertTextKey(GameInfo.Units[unit:GetUnitType()].Description)
+
+    -- Check if unit can upgrade
+    local upgradeType = unit:GetUpgradeUnitType()
+    if upgradeType == -1 then
+      return { Success = false, UnitID = unitID, OldType = oldType, Message = "No upgrade available" }
+    end
+
+    if not unit:CanUpgradeRightNow() then
+      return { Success = false, UnitID = unitID, OldType = oldType, Message = "Cannot upgrade right now (not in friendly territory or other restriction)" }
+    end
+
+    local cost = unit:UpgradePrice(upgradeType)
+    if player:GetGold() < cost then
+      return { Success = false, UnitID = unitID, OldType = oldType, GoldCost = cost, Message = "Not enough gold (need " .. cost .. ")" }
+    end
+
+    local newType = Locale.ConvertTextKey(GameInfo.Units[upgradeType].Description)
+
+    -- Do the upgrade
+    player:ChangeGold(-cost)
+    unit:DoUpgrade()
+
+    return {
+      Success = true,
+      UnitID = unitID,
+      OldType = oldType,
+      NewType = newType,
+      GoldCost = cost,
+      Message = "Upgraded " .. oldType .. " to " .. newType
+    }
+  `;
+
+  async execute(args: z.infer<typeof this.inputSchema>): Promise<z.infer<typeof this.outputSchema>> {
+    return await super.call(args.PlayerID, args.UnitID);
+  }
+}
+
+export default function createUpgradeUnitTool() {
+  return new UpgradeUnitTool();
+}

--- a/mcp-server/src/tools/actions/use-great-person.ts
+++ b/mcp-server/src/tools/actions/use-great-person.ts
@@ -1,0 +1,188 @@
+/**
+ * Great person ability tool for AI player control
+ */
+
+import { LuaFunctionTool } from "../abstract/lua-function.js";
+import * as z from "zod";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { MaxMajorCivs } from "../../knowledge/schema/base.js";
+
+const UseGreatPersonResultSchema = z.object({
+  Success: z.boolean(),
+  UnitID: z.number(),
+  UnitType: z.string().optional(),
+  Action: z.string().optional(),
+  Message: z.string().optional(),
+});
+
+type UseGreatPersonResultType = z.infer<typeof UseGreatPersonResultSchema>;
+
+class UseGreatPersonTool extends LuaFunctionTool<UseGreatPersonResultType> {
+  readonly name = "use-great-person";
+
+  readonly description = `Use a great person's special ability.
+
+Actions depend on the great person type:
+- Great Artist: Create great work OR start golden age
+- Great Scientist: Discover tech OR build academy
+- Great Engineer: Hurry production OR build manufactory
+- Great Merchant: Trade mission OR build customs house
+- Great General: Build citadel
+- Great Admiral: Repair fleet
+- Great Prophet: Spread religion, build holy site, enhance religion
+- Great Writer: Create great work OR political treatise
+- Great Musician: Create great work OR concert tour`;
+
+  inputSchema = z.object({
+    PlayerID: z.number().min(0).max(MaxMajorCivs - 1)
+      .describe("Player ID (owner of the great person)"),
+    UnitID: z.number()
+      .describe("The great person unit's ID"),
+    Action: z.enum([
+      "GOLDEN_AGE",      // Great Artist
+      "CREATE_WORK",     // Artist, Writer, Musician
+      "DISCOVER_TECH",   // Great Scientist
+      "BUILD_IMPROVEMENT", // All (academy, manufactory, etc.)
+      "HURRY_PRODUCTION", // Great Engineer
+      "TRADE_MISSION",   // Great Merchant
+      "BUILD_CITADEL",   // Great General
+      "REPAIR_FLEET",    // Great Admiral
+      "SPREAD_RELIGION", // Great Prophet
+      "CONCERT_TOUR",    // Great Musician
+      "POLITICAL_TREATISE" // Great Writer
+    ]).describe("The action to perform"),
+  });
+
+  protected resultSchema = UseGreatPersonResultSchema;
+  protected arguments = ["playerID", "unitID", "action"];
+
+  readonly annotations: ToolAnnotations = {
+    readOnlyHint: false
+  };
+
+  protected script = `
+    local player = Players[playerID]
+    if not player then
+      return { Success = false, UnitID = unitID, Action = action, Message = "Invalid player" }
+    end
+
+    local unit = player:GetUnitByID(unitID)
+    if not unit then
+      return { Success = false, UnitID = unitID, Action = action, Message = "Unit not found" }
+    end
+
+    local unitInfo = GameInfo.Units[unit:GetUnitType()]
+    local unitTypeName = Locale.ConvertTextKey(unitInfo.Description)
+
+    local success = false
+    local message = ""
+
+    if action == "GOLDEN_AGE" then
+      if unit:CanGoldenAge(unit:GetPlot()) then
+        unit:DoGoldenAge()
+        success = true
+        message = "Golden age started"
+      else
+        message = "Cannot trigger golden age"
+      end
+    elseif action == "CREATE_WORK" then
+      if unit:CanGreatWork(unit:GetPlot()) then
+        unit:DoGreatWork()
+        success = true
+        message = "Great work created"
+      else
+        message = "Cannot create great work here"
+      end
+    elseif action == "DISCOVER_TECH" then
+      if unit:CanDiscover(unit:GetPlot()) then
+        unit:Discover()
+        success = true
+        message = "Technology discovered"
+      else
+        message = "Cannot discover technology"
+      end
+    elseif action == "BUILD_IMPROVEMENT" then
+      if unit:CanConstruct(unit:GetPlot()) then
+        unit:DoConstruct()
+        success = true
+        message = "Special improvement built"
+      else
+        message = "Cannot build improvement here"
+      end
+    elseif action == "HURRY_PRODUCTION" then
+      if unit:CanHurry(unit:GetPlot()) then
+        unit:Hurry()
+        success = true
+        message = "Production hurried"
+      else
+        message = "Cannot hurry production"
+      end
+    elseif action == "TRADE_MISSION" then
+      if unit:CanTrade(unit:GetPlot()) then
+        unit:DoTrade()
+        success = true
+        message = "Trade mission completed"
+      else
+        message = "Cannot perform trade mission"
+      end
+    elseif action == "BUILD_CITADEL" then
+      if unit:CanGeneralTactic(unit:GetPlot()) then
+        unit:DoGeneralTactic()
+        success = true
+        message = "Citadel built"
+      else
+        message = "Cannot build citadel here"
+      end
+    elseif action == "REPAIR_FLEET" then
+      if unit:CanRepairFleet(unit:GetPlot()) then
+        unit:DoRepairFleet()
+        success = true
+        message = "Fleet repaired"
+      else
+        message = "Cannot repair fleet"
+      end
+    elseif action == "SPREAD_RELIGION" then
+      if unit:CanSpreadReligion(unit:GetPlot()) then
+        unit:DoSpreadReligion()
+        success = true
+        message = "Religion spread"
+      else
+        message = "Cannot spread religion here"
+      end
+    elseif action == "CONCERT_TOUR" then
+      if unit:CanBlastTourism(unit:GetPlot()) then
+        unit:DoBlastTourism()
+        success = true
+        message = "Concert tour performed"
+      else
+        message = "Cannot perform concert tour"
+      end
+    elseif action == "POLITICAL_TREATISE" then
+      if unit:CanPoliticalTreatise(unit:GetPlot()) then
+        unit:DoPoliticalTreatise()
+        success = true
+        message = "Political treatise written"
+      else
+        message = "Cannot write political treatise"
+      end
+    else
+      message = "Unknown action"
+    end
+
+    return {
+      Success = success,
+      UnitID = unitID,
+      UnitType = unitTypeName,
+      Action = action,
+      Message = message
+    }
+  `;
+
+  async execute(args: z.infer<typeof this.inputSchema>): Promise<z.infer<typeof this.outputSchema>> {
+    return await super.call(args.PlayerID, args.UnitID, args.Action);
+  }
+}
+
+export default function createUseGreatPersonTool() {
+  return new UseGreatPersonTool();
+}

--- a/mcp-server/src/tools/actions/world-congress-vote.ts
+++ b/mcp-server/src/tools/actions/world-congress-vote.ts
@@ -1,0 +1,106 @@
+/**
+ * World Congress voting tool for AI player control
+ */
+
+import { LuaFunctionTool } from "../abstract/lua-function.js";
+import * as z from "zod";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { MaxMajorCivs } from "../../knowledge/schema/base.js";
+
+const WorldCongressVoteResultSchema = z.object({
+  Success: z.boolean(),
+  ResolutionName: z.string().optional(),
+  VotesUsed: z.number().optional(),
+  VoteChoice: z.string().optional(),
+  Message: z.string().optional(),
+});
+
+type WorldCongressVoteResultType = z.infer<typeof WorldCongressVoteResultSchema>;
+
+class WorldCongressVoteTool extends LuaFunctionTool<WorldCongressVoteResultType> {
+  readonly name = "world-congress-vote";
+
+  readonly description = `Cast votes in World Congress / United Nations.
+
+Use get-world-congress to see current proposals and available votes.
+You can vote YES, NO, or for a specific CHOICE (for targeted resolutions).`;
+
+  inputSchema = z.object({
+    PlayerID: z.number().min(0).max(MaxMajorCivs - 1)
+      .describe("Your player ID"),
+    ResolutionIndex: z.number().min(0)
+      .describe("Index of the resolution to vote on"),
+    Choice: z.number()
+      .describe("Vote choice: 0=NO, 1=YES, or specific choice ID for targeted resolutions"),
+    NumVotes: z.number().min(1)
+      .describe("Number of votes to commit to this choice"),
+  });
+
+  protected resultSchema = WorldCongressVoteResultSchema;
+  protected arguments = ["playerID", "resolutionIndex", "choice", "numVotes"];
+
+  readonly annotations: ToolAnnotations = {
+    readOnlyHint: false
+  };
+
+  protected script = `
+    local player = Players[playerID]
+    if not player then
+      return { Success = false, Message = "Invalid player" }
+    end
+
+    local league = Game.GetActiveLeague()
+    if not league then
+      return { Success = false, Message = "World Congress not active" }
+    end
+
+    if not league:IsInSession() then
+      return { Success = false, Message = "Congress is not in session" }
+    end
+
+    -- Get available votes
+    local votesAvailable = league:GetRemainingVotesForMember(playerID)
+    if votesAvailable < numVotes then
+      return { Success = false, Message = "Not enough votes (have " .. votesAvailable .. ", need " .. numVotes .. ")" }
+    end
+
+    -- Get the proposal
+    local proposals = league:GetProposals()
+    if resolutionIndex >= #proposals then
+      return { Success = false, Message = "Invalid resolution index" }
+    end
+
+    local proposal = proposals[resolutionIndex + 1]
+    local resolutionInfo = GameInfo.Resolutions[proposal.Type]
+    local resolutionName = resolutionInfo and Locale.ConvertTextKey(resolutionInfo.Description) or "Unknown Resolution"
+
+    -- Cast the vote
+    local success = league:DoVoteCommit(playerID, resolutionIndex, choice, numVotes)
+
+    local choiceStr = choice == 0 and "NO" or (choice == 1 and "YES" or "Choice " .. choice)
+
+    if success then
+      return {
+        Success = true,
+        ResolutionName = resolutionName,
+        VotesUsed = numVotes,
+        VoteChoice = choiceStr,
+        Message = "Cast " .. numVotes .. " vote(s) " .. choiceStr .. " on " .. resolutionName
+      }
+    else
+      return {
+        Success = false,
+        ResolutionName = resolutionName,
+        Message = "Failed to cast vote"
+      }
+    end
+  `;
+
+  async execute(args: z.infer<typeof this.inputSchema>): Promise<z.infer<typeof this.outputSchema>> {
+    return await super.call(args.PlayerID, args.ResolutionIndex, args.Choice, args.NumVotes);
+  }
+}
+
+export default function createWorldCongressVoteTool() {
+  return new WorldCongressVoteTool();
+}

--- a/mcp-server/src/tools/index.ts
+++ b/mcp-server/src/tools/index.ts
@@ -28,6 +28,13 @@ import createSetResearchTool from "./actions/set-research.js";
 import createSetPolicyTool from "./actions/set-policy.js";
 import createGetVictoryProgressTool from "./knowledge/get-victory-progress.js";
 import createGetMilitaryReportTool from "./knowledge/get-military-report.js";
+import createGetMapRegionTool from "./knowledge/get-map-region.js";
+import createGetCombatPreviewTool from "./knowledge/get-combat-preview.js";
+import createGetHappinessTool from "./knowledge/get-happiness.js";
+import createGetWorldCongressTool from "./knowledge/get-world-congress.js";
+import createGetTradeRoutesTool from "./knowledge/get-trade-routes.js";
+import createGetEspionageTool from "./knowledge/get-espionage.js";
+import createGetCultureInfluenceTool from "./knowledge/get-culture-influence.js";
 import createSearchDatabaseTool from "./general/search-database.js";
 
 // Tool factory configuration - one line per tool
@@ -44,6 +51,13 @@ const toolFactories = {
     getMilitaryStrategy: createGetMilitaryStrategyTool,
     getVictoryProgress: createGetVictoryProgressTool,
     getMilitaryReport: createGetMilitaryReportTool,
+    getMapRegion: createGetMapRegionTool,
+    getCombatPreview: createGetCombatPreviewTool,
+    getHappiness: createGetHappinessTool,
+    getWorldCongress: createGetWorldCongressTool,
+    getTradeRoutes: createGetTradeRoutesTool,
+    getEspionage: createGetEspionageTool,
+    getCultureInfluence: createGetCultureInfluenceTool,
     getEvents: createGetEventsTool,
     getPlayers: createGetPlayersTool,
     getOpinions: createGetOpinionsTool,

--- a/mcp-server/src/tools/index.ts
+++ b/mcp-server/src/tools/index.ts
@@ -42,6 +42,18 @@ import createRangedAttackTool from "./actions/ranged-attack.js";
 import createSetCityProductionTool from "./actions/set-city-production.js";
 import createBuildImprovementTool from "./actions/build-improvement.js";
 import createFoundCityTool from "./actions/found-city.js";
+import createDeclareWarTool from "./actions/declare-war.js";
+import createMakePeaceTool from "./actions/make-peace.js";
+import createUnitCommandTool from "./actions/unit-command.js";
+import createUpgradeUnitTool from "./actions/upgrade-unit.js";
+import createCityPurchaseTool from "./actions/city-purchase.js";
+import createAssignTradeRouteTool from "./actions/assign-trade-route.js";
+import createMoveSpyTool from "./actions/move-spy.js";
+import createUseGreatPersonTool from "./actions/use-great-person.js";
+import createWorldCongressVoteTool from "./actions/world-congress-vote.js";
+import createSellBuildingTool from "./actions/sell-building.js";
+import createSpreadReligionTool from "./actions/spread-religion.js";
+import createDenounceTool from "./actions/denounce.js";
 
 // Tool factory configuration - one line per tool
 const toolFactories = {
@@ -83,13 +95,28 @@ const toolFactories = {
     keepStatusQuo: createKeepStatusQuoTool,
     pauseGame: createPauseGameTool,
     resumeGame: createResumeGameTool,
-    // Direct control tools
+    // Direct control tools - units
     moveUnit: createMoveUnitTool,
     attackUnit: createAttackUnitTool,
     rangedAttack: createRangedAttackTool,
-    setCityProduction: createSetCityProductionTool,
+    unitCommand: createUnitCommandTool,
+    upgradeUnit: createUpgradeUnitTool,
     buildImprovement: createBuildImprovementTool,
     foundCity: createFoundCityTool,
+    useGreatPerson: createUseGreatPersonTool,
+    spreadReligion: createSpreadReligionTool,
+    // Direct control tools - cities
+    setCityProduction: createSetCityProductionTool,
+    cityPurchase: createCityPurchaseTool,
+    sellBuilding: createSellBuildingTool,
+    // Direct control tools - diplomacy
+    declareWar: createDeclareWarTool,
+    makePeace: createMakePeaceTool,
+    denounce: createDenounceTool,
+    // Direct control tools - systems
+    assignTradeRoute: createAssignTradeRouteTool,
+    moveSpy: createMoveSpyTool,
+    worldCongressVote: createWorldCongressVoteTool,
 } as const;
  
 // Type for the tools object (inferred from factories)

--- a/mcp-server/src/tools/index.ts
+++ b/mcp-server/src/tools/index.ts
@@ -36,6 +36,12 @@ import createGetTradeRoutesTool from "./knowledge/get-trade-routes.js";
 import createGetEspionageTool from "./knowledge/get-espionage.js";
 import createGetCultureInfluenceTool from "./knowledge/get-culture-influence.js";
 import createSearchDatabaseTool from "./general/search-database.js";
+import createMoveUnitTool from "./actions/move-unit.js";
+import createAttackUnitTool from "./actions/attack-unit.js";
+import createRangedAttackTool from "./actions/ranged-attack.js";
+import createSetCityProductionTool from "./actions/set-city-production.js";
+import createBuildImprovementTool from "./actions/build-improvement.js";
+import createFoundCityTool from "./actions/found-city.js";
 
 // Tool factory configuration - one line per tool
 const toolFactories = {
@@ -77,6 +83,13 @@ const toolFactories = {
     keepStatusQuo: createKeepStatusQuoTool,
     pauseGame: createPauseGameTool,
     resumeGame: createResumeGameTool,
+    // Direct control tools
+    moveUnit: createMoveUnitTool,
+    attackUnit: createAttackUnitTool,
+    rangedAttack: createRangedAttackTool,
+    setCityProduction: createSetCityProductionTool,
+    buildImprovement: createBuildImprovementTool,
+    foundCity: createFoundCityTool,
 } as const;
  
 // Type for the tools object (inferred from factories)

--- a/mcp-server/src/tools/knowledge/get-combat-preview.ts
+++ b/mcp-server/src/tools/knowledge/get-combat-preview.ts
@@ -1,0 +1,222 @@
+/**
+ * Tool for retrieving combat predictions before attacking
+ * Provides the "what if I attacked?" preview that sighted players see when hovering
+ *
+ * Related: Issue #469 - AI Accessibility in Games
+ *
+ * Kali ❤️‍🔥 [Visionary]: This is the MOST important tactical information
+ * Athena 🦉 [Reviewer]: Exposes Game.GetCombatPrediction() + damage calculations
+ * Nemesis 💀 [Accessibility]: Without this, you're playing blind (pun intended)
+ */
+
+import { ToolBase } from "../base.js";
+import * as z from "zod";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import {
+  getCombatPreview,
+  findBestTarget,
+  findAvoidTargets,
+} from "../../knowledge/getters/combat-preview.js";
+import { MaxMajorCivs } from "../../knowledge/schema/base.js";
+
+/**
+ * Input schema
+ */
+const GetCombatPreviewInputSchema = z.object({
+  // Player perspective
+  PlayerID: z.number().min(0).max(MaxMajorCivs - 1).optional()
+    .describe("Player ID (default: 0)"),
+
+  // Specific attack query
+  AttackerUnitID: z.number().describe("ID of the attacking unit"),
+  DefenderUnitID: z.number().optional()
+    .describe("ID of specific defender unit (optional)"),
+
+  // Get all targets
+  ShowAllTargets: z.boolean().default(false)
+    .describe("If true, show predictions for all valid targets in range"),
+
+  // Include recommendations
+  IncludeRecommendations: z.boolean().default(true)
+    .describe("Include best target and avoid recommendations"),
+});
+
+/**
+ * Combat modifier schema
+ */
+const CombatModifierSchema = z.object({
+  Source: z.string().describe("What's providing the modifier"),
+  Value: z.number().describe("Percentage modifier (+25, -10, etc.)"),
+});
+
+/**
+ * Attacker info schema
+ */
+const AttackerInfoSchema = z.object({
+  ID: z.number(),
+  Name: z.string(),
+  Owner: z.string(),
+  X: z.number(),
+  Y: z.number(),
+  CurrentHP: z.number(),
+  MaxHP: z.number(),
+  BaseStrength: z.number(),
+  RangedStrength: z.number().optional(),
+  Moves: z.number().optional(),
+  MaxMoves: z.number().optional(),
+});
+
+/**
+ * Defender info schema
+ */
+const DefenderInfoSchema = z.object({
+  ID: z.number(),
+  Name: z.string(),
+  Type: z.enum(["Unit", "City"]),
+  Owner: z.string(),
+  X: z.number(),
+  Y: z.number(),
+  CurrentHP: z.number(),
+  MaxHP: z.number(),
+  BaseStrength: z.number(),
+});
+
+/**
+ * Combat prediction schema
+ */
+const CombatPredictionSchema = z.object({
+  Attacker: AttackerInfoSchema,
+  Defender: DefenderInfoSchema,
+
+  // The key prediction - matches the UI icons
+  Prediction: z.enum([
+    "TotalVictory",   // We kill them, minimal damage to us
+    "MajorVictory",   // We kill them, some damage to us
+    "SmallVictory",   // We do more damage than we take
+    "Stalemate",      // Roughly equal exchange
+    "SmallDefeat",    // We take more damage than we deal
+    "MajorDefeat",    // We take heavy damage
+    "TotalDefeat",    // We die
+    "Ranged",         // Ranged attack (no counter-damage)
+    "Unknown",
+  ]).describe("Overall combat prediction"),
+
+  // Damage numbers
+  ExpectedDamageToDefender: z.number().describe("HP damage we expect to deal"),
+  ExpectedDamageToAttacker: z.number().describe("HP damage we expect to take"),
+  DefenderWouldDie: z.boolean(),
+  AttackerWouldDie: z.boolean(),
+
+  // Risk assessment
+  RiskLevel: z.enum(["Safe", "Favorable", "Risky", "Dangerous", "Suicidal"]),
+
+  // Combat type
+  IsRanged: z.boolean(),
+  CanCounterAttack: z.boolean(),
+
+  // Modifiers breakdown
+  AttackerModifiers: z.array(CombatModifierSchema),
+  DefenderModifiers: z.array(CombatModifierSchema),
+});
+
+/**
+ * Output schema
+ */
+const GetCombatPreviewOutputSchema = z.object({
+  // All predictions
+  Predictions: z.array(CombatPredictionSchema),
+
+  // Recommendations
+  BestTarget: z.object({
+    DefenderName: z.string(),
+    Prediction: z.string(),
+    Reason: z.string(),
+  }).optional().describe("Recommended target if multiple options"),
+
+  AvoidTargets: z.array(z.object({
+    DefenderName: z.string(),
+    Reason: z.string(),
+  })).optional().describe("Targets that would result in defeat"),
+});
+
+/**
+ * Type exports
+ */
+export type CombatPreviewOutput = z.infer<typeof GetCombatPreviewOutputSchema>;
+
+/**
+ * Tool for combat previews
+ */
+class GetCombatPreviewTool extends ToolBase {
+  readonly name = "get-combat-preview";
+
+  readonly description = `Predicts combat outcomes before committing to an attack.
+
+Use this to understand:
+- Expected damage dealt and received
+- Whether attacker/defender would die
+- Combat modifiers affecting the fight (terrain, flanking, health)
+- Risk level of the engagement (Safe → Suicidal)
+- Best target recommendation if multiple options
+
+This provides the "what if I attacked?" preview that sighted players see when hovering over enemies.`;
+
+  readonly inputSchema = GetCombatPreviewInputSchema;
+  readonly outputSchema = GetCombatPreviewOutputSchema;
+
+  readonly annotations: ToolAnnotations = {
+    readOnlyHint: true
+  };
+
+  readonly metadata = {
+    autoComplete: ["PlayerID", "AttackerUnitID", "DefenderUnitID"],
+  };
+
+  async execute(args: z.infer<typeof this.inputSchema>): Promise<z.infer<typeof this.outputSchema>> {
+    const {
+      PlayerID,
+      AttackerUnitID,
+      DefenderUnitID,
+      ShowAllTargets,
+      IncludeRecommendations
+    } = args;
+
+    const playerID = PlayerID ?? 0;
+
+    // Get predictions
+    const predictions = await getCombatPreview(
+      playerID,
+      AttackerUnitID,
+      DefenderUnitID,
+      ShowAllTargets
+    );
+
+    // Build output
+    const result: z.infer<typeof this.outputSchema> = {
+      Predictions: predictions,
+    };
+
+    // Add recommendations if requested and we have multiple predictions
+    if (IncludeRecommendations && predictions.length > 0) {
+      const bestTarget = findBestTarget(predictions);
+      const avoidTargets = findAvoidTargets(predictions);
+
+      if (bestTarget) {
+        result.BestTarget = bestTarget;
+      }
+
+      if (avoidTargets.length > 0) {
+        result.AvoidTargets = avoidTargets;
+      }
+    }
+
+    return result;
+  }
+}
+
+/**
+ * Creates a new instance of the combat preview tool
+ */
+export default function createGetCombatPreviewTool() {
+  return new GetCombatPreviewTool();
+}

--- a/mcp-server/src/tools/knowledge/get-culture-influence.ts
+++ b/mcp-server/src/tools/knowledge/get-culture-influence.ts
@@ -1,0 +1,84 @@
+/**
+ * Culture/Tourism influence tool for AI accessibility (Issue #469)
+ */
+
+import { ToolBase } from "../base.js";
+import * as z from "zod";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { getCultureInfluence } from "../../knowledge/getters/culture-influence.js";
+import { MaxMajorCivs } from "../../knowledge/schema/base.js";
+
+const GetCultureInfluenceInputSchema = z.object({
+  PlayerID: z.number().min(0).max(MaxMajorCivs - 1).optional()
+    .describe("Player ID (default: 0)"),
+});
+
+const InfluenceSchema = z.object({
+  CivName: z.string(),
+  InfluenceLevel: z.enum(["Unknown", "Exotic", "Familiar", "Popular", "Influential", "Dominant"]),
+  InfluencePercent: z.number(),
+  TheirCulturePerTurn: z.number().optional(),
+  TourismTowardThem: z.number().optional(),
+  TurnsToNextLevel: z.number().optional(),
+});
+
+const CityCultureSchema = z.object({
+  Name: z.string(),
+  CulturePerTurn: z.number(),
+  TourismPerTurn: z.number(),
+  GreatWorks: z.number(),
+});
+
+const GetCultureInfluenceOutputSchema = z.object({
+  OurCulturePerTurn: z.number(),
+  OurTourismPerTurn: z.number(),
+
+  OurIdeology: z.string().optional(),
+  IdeologyLevel: z.number().describe("Number of tenets adopted"),
+
+  InfluenceOnOthers: z.array(InfluenceSchema).describe("Our cultural influence on other civs"),
+  InfluenceOnUs: z.array(InfluenceSchema).describe("Other civs' influence on us"),
+
+  PublicOpinion: z.enum(["Content", "Dissidents", "Civil Resistance", "Revolutionary Wave"]),
+  PublicOpinionUnhappiness: z.number(),
+  PreferredIdeology: z.string().optional().describe("What ideology people want if unhappy"),
+
+  GreatWorksCount: z.number(),
+  ThemedBonuses: z.number(),
+
+  CultureByCity: z.array(CityCultureSchema),
+});
+
+class GetCultureInfluenceTool extends ToolBase {
+  readonly name = "get-culture-influence";
+
+  readonly description = `Get tourism, cultural influence, and ideology status.
+
+Shows:
+- Our culture and tourism output
+- Influence level on each civilization (Unknown → Dominant)
+- Other civs' influence on us
+- Public opinion and ideology pressure
+- Great works count per city
+- Turns to next influence level`;
+
+  readonly inputSchema = GetCultureInfluenceInputSchema;
+  readonly outputSchema = GetCultureInfluenceOutputSchema;
+
+  readonly annotations: ToolAnnotations = { readOnlyHint: true };
+
+  async execute(args: z.infer<typeof this.inputSchema>): Promise<z.infer<typeof this.outputSchema>> {
+    const playerID = args.PlayerID ?? 0;
+    const data = await getCultureInfluence(playerID);
+
+    if (!data) {
+      throw new Error('Failed to get culture influence data');
+    }
+
+    return data;
+  }
+}
+
+export default function createGetCultureInfluenceTool() {
+  return new GetCultureInfluenceTool();
+}

--- a/mcp-server/src/tools/knowledge/get-espionage.ts
+++ b/mcp-server/src/tools/knowledge/get-espionage.ts
@@ -1,0 +1,80 @@
+/**
+ * Espionage tool for AI accessibility (Issue #469)
+ */
+
+import { ToolBase } from "../base.js";
+import * as z from "zod";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { getEspionage } from "../../knowledge/getters/espionage.js";
+import { MaxMajorCivs } from "../../knowledge/schema/base.js";
+
+const GetEspionageInputSchema = z.object({
+  PlayerID: z.number().min(0).max(MaxMajorCivs - 1).optional()
+    .describe("Player ID (default: 0)"),
+});
+
+const SpySchema = z.object({
+  Name: z.string(),
+  Rank: z.number(),
+  Location: z.string().optional(),
+  LocationOwner: z.string().optional(),
+  State: z.enum([
+    "Unassigned", "Travelling", "GatheringIntel", "CounterIntelligence",
+    "Schmoozing", "RiggingElection", "StagingCoup", "Diplomat", "Surveillance", "Unknown"
+  ]),
+  TurnsInState: z.number().optional(),
+});
+
+const CityIntelSchema = z.object({
+  CityName: z.string(),
+  Owner: z.string(),
+  Population: z.number().optional(),
+  HasOurSpy: z.boolean(),
+  EspionagePotential: z.number().optional().describe("Higher = more valuable target"),
+  IsCapital: z.boolean().optional(),
+  IsOurCity: z.boolean().optional(),
+});
+
+const IntrigueSchema = z.object({
+  Turn: z.number(),
+  Message: z.string(),
+  SpyName: z.string().optional(),
+});
+
+const GetEspionageOutputSchema = z.object({
+  Spies: z.array(SpySchema),
+  CityIntelligence: z.array(CityIntelSchema),
+  IntrigueMessages: z.array(IntrigueSchema).describe("Recent intelligence reports"),
+});
+
+class GetEspionageTool extends ToolBase {
+  readonly name = "get-espionage";
+
+  readonly description = `Get spy locations, states, and intelligence.
+
+Shows:
+- All spies with their locations and current activities
+- City espionage potential ratings
+- Intrigue messages (intelligence reports)
+- Counterintelligence status in our cities`;
+
+  readonly inputSchema = GetEspionageInputSchema;
+  readonly outputSchema = GetEspionageOutputSchema;
+
+  readonly annotations: ToolAnnotations = { readOnlyHint: true };
+
+  async execute(args: z.infer<typeof this.inputSchema>): Promise<z.infer<typeof this.outputSchema>> {
+    const playerID = args.PlayerID ?? 0;
+    const data = await getEspionage(playerID);
+
+    if (!data) {
+      throw new Error('Failed to get espionage data');
+    }
+
+    return data;
+  }
+}
+
+export default function createGetEspionageTool() {
+  return new GetEspionageTool();
+}

--- a/mcp-server/src/tools/knowledge/get-happiness.ts
+++ b/mcp-server/src/tools/knowledge/get-happiness.ts
@@ -1,0 +1,96 @@
+/**
+ * Happiness breakdown tool for AI accessibility (Issue #469)
+ */
+
+import { ToolBase } from "../base.js";
+import * as z from "zod";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { getHappiness } from "../../knowledge/getters/happiness.js";
+import { MaxMajorCivs } from "../../knowledge/schema/base.js";
+
+const GetHappinessInputSchema = z.object({
+  PlayerID: z.number().min(0).max(MaxMajorCivs - 1).optional()
+    .describe("Player ID (default: 0)"),
+});
+
+const CityHappinessSchema = z.object({
+  Name: z.string(),
+  LocalHappiness: z.number(),
+  Unhappiness: z.number(),
+  IsResistance: z.boolean().optional(),
+  ResistanceTurns: z.number().optional(),
+  IsOccupied: z.boolean().optional(),
+  WLTKD: z.number().optional().describe("We Love The King Day turns remaining"),
+});
+
+const GetHappinessOutputSchema = z.object({
+  TotalHappiness: z.number(),
+  TotalUnhappiness: z.number(),
+  NetHappiness: z.number().describe("Positive = happy, negative = unhappy"),
+
+  HappinessSources: z.object({
+    FromCities: z.number(),
+    FromTradeRoutes: z.number(),
+    FromReligion: z.number(),
+    FromNaturalWonders: z.number(),
+    FromMinorCivs: z.number(),
+    FromLeagues: z.number(),
+    FromVassals: z.number(),
+    FromLuxuries: z.number(),
+    FromPolicies: z.number(),
+    FromBuildings: z.number(),
+    FromExtraHappinessPerCity: z.number(),
+  }),
+
+  UnhappinessSources: z.object({
+    FromCities: z.number(),
+    FromPopulation: z.number(),
+    FromOccupation: z.number(),
+    FromPublicOpinion: z.number(),
+    FromUnits: z.number(),
+    FromCitySpecialists: z.number(),
+    FromWarWeariness: z.number(),
+  }),
+
+  IsGoldenAge: z.boolean(),
+  GoldenAgeProgress: z.number(),
+  GoldenAgeThreshold: z.number(),
+  GoldenAgeTurnsLeft: z.number(),
+  TurnsToGoldenAge: z.number().optional(),
+
+  CityHappiness: z.array(CityHappinessSchema),
+  Warnings: z.array(z.string()),
+});
+
+class GetHappinessTool extends ToolBase {
+  readonly name = "get-happiness";
+
+  readonly description = `Get full happiness/unhappiness breakdown.
+
+Shows:
+- Total happiness and unhappiness with net value
+- Per-source breakdown (cities, trade, religion, luxuries, etc.)
+- Golden age status and progress
+- Per-city happiness details
+- Warnings about unhappiness issues`;
+
+  readonly inputSchema = GetHappinessInputSchema;
+  readonly outputSchema = GetHappinessOutputSchema;
+
+  readonly annotations: ToolAnnotations = { readOnlyHint: true };
+
+  async execute(args: z.infer<typeof this.inputSchema>): Promise<z.infer<typeof this.outputSchema>> {
+    const playerID = args.PlayerID ?? 0;
+    const data = await getHappiness(playerID);
+
+    if (!data) {
+      throw new Error('Failed to get happiness data');
+    }
+
+    return data;
+  }
+}
+
+export default function createGetHappinessTool() {
+  return new GetHappinessTool();
+}

--- a/mcp-server/src/tools/knowledge/get-map-region.ts
+++ b/mcp-server/src/tools/knowledge/get-map-region.ts
@@ -1,0 +1,239 @@
+/**
+ * Tool for retrieving map region data for AI accessibility
+ * Provides spatial awareness that sighted players get from looking at the map
+ *
+ * Related: Issue #469 - AI Accessibility in Games
+ *
+ * Kali ❤️‍🔥 [Visionary]: This is what lets AI "see" the map
+ * Athena 🦉 [Reviewer]: Exposes terrain, features, resources, improvements
+ * Nemesis 💀 [Accessibility]: Parity with sighted player experience
+ */
+
+import { ToolBase } from "../base.js";
+import * as z from "zod";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { getMapRegion, generateSpatialNotes, TileData } from "../../knowledge/getters/map-region.js";
+import { MaxMajorCivs } from "../../knowledge/schema/base.js";
+
+/**
+ * Input schema for the GetMapRegion tool
+ */
+const GetMapRegionInputSchema = z.object({
+  // Center point + radius query
+  CenterX: z.number().describe("X coordinate of region center"),
+  CenterY: z.number().describe("Y coordinate of region center"),
+  Radius: z.number().min(1).max(10).default(5).describe("Radius in tiles (1-10, default 5)"),
+
+  // Player perspective
+  PlayerID: z.number().min(0).max(MaxMajorCivs - 1).optional()
+    .describe("Player ID for visibility filtering (default: active player)"),
+
+  // Options
+  IncludeUnits: z.boolean().default(true).describe("Include unit information on tiles"),
+  IncludeYields: z.boolean().default(false).describe("Include tile yield breakdown"),
+  IncludeSpatialNotes: z.boolean().default(true).describe("Include AI-generated spatial analysis"),
+});
+
+/**
+ * Schema for unit data on a tile
+ */
+const TileUnitSchema = z.object({
+  Name: z.string(),
+  Owner: z.string(),
+  Strength: z.number().optional(),
+  RangedStrength: z.number().optional(),
+  Health: z.number().describe("Health percentage"),
+});
+
+/**
+ * Schema for tile yields
+ */
+const TileYieldsSchema = z.object({
+  Food: z.number(),
+  Production: z.number(),
+  Gold: z.number(),
+  Science: z.number(),
+  Culture: z.number(),
+  Faith: z.number(),
+});
+
+/**
+ * Schema for individual tile data
+ */
+const TileDataSchema = z.object({
+  // Location
+  X: z.number(),
+  Y: z.number(),
+
+  // Visibility
+  Visibility: z.enum(["Visible", "Revealed", "Hidden"]),
+
+  // Terrain
+  Terrain: z.string().optional().describe("Base terrain: Grassland, Plains, Desert, etc."),
+  IsHills: z.boolean().optional(),
+  IsMountain: z.boolean().optional(),
+  Feature: z.string().optional().describe("Feature: Forest, Jungle, Marsh, etc."),
+
+  // Water
+  IsRiver: z.boolean().optional(),
+  IsFreshWater: z.boolean().optional(),
+  IsLake: z.boolean().optional(),
+  IsCoastal: z.boolean().optional(),
+
+  // Resources
+  Resource: z.string().optional(),
+  ResourceQuantity: z.number().optional(),
+  ResourceClass: z.enum(["Bonus", "Strategic", "Luxury"]).optional(),
+  ResourceImproved: z.boolean().optional(),
+
+  // Improvements
+  Improvement: z.string().optional(),
+  ImprovementPillaged: z.boolean().optional(),
+  Route: z.string().optional(),
+  RoutePillaged: z.boolean().optional(),
+
+  // Ownership
+  Owner: z.string().optional(),
+  City: z.string().optional(),
+  WorkedByCity: z.string().optional(),
+
+  // Units
+  Units: z.array(TileUnitSchema).optional(),
+
+  // Combat modifiers
+  DefenseModifier: z.number().optional().describe("Defense bonus percentage"),
+  MovementCost: z.number().optional().describe("Movement points to enter"),
+
+  // Yields
+  Yields: TileYieldsSchema.optional(),
+});
+
+/**
+ * Output schema for the tool
+ */
+const GetMapRegionOutputSchema = z.object({
+  // Summary statistics
+  Summary: z.object({
+    TotalTiles: z.number(),
+    VisibleTiles: z.number(),
+    RevealedTiles: z.number(),
+    TerrainBreakdown: z.record(z.string(), z.number()).describe("Count of each terrain type"),
+    ResourcesFound: z.array(z.string()).describe("Unique resources in region"),
+  }),
+
+  // Tile data keyed by "X,Y"
+  Tiles: z.record(z.string(), TileDataSchema),
+
+  // AI-generated spatial analysis
+  SpatialNotes: z.array(z.string()).optional()
+    .describe("Notable features: chokepoints, clusters, defensive positions"),
+});
+
+/**
+ * Type exports
+ */
+export type MapRegionOutput = z.infer<typeof GetMapRegionOutputSchema>;
+
+/**
+ * Tool for retrieving map region data
+ */
+class GetMapRegionTool extends ToolBase {
+  readonly name = "get-map-region";
+
+  readonly description = `Retrieves terrain, features, resources, and improvements for a map region.
+
+Use this to understand:
+- Geography and terrain (mountains, rivers, forests, hills)
+- Resource locations (strategic, luxury, bonus) and whether they're improved
+- Improvements and roads (what's built, what's pillaged)
+- Defensive positions and movement costs
+- Spatial relationships (the SpatialNotes field highlights notable features)
+
+This provides spatial awareness that complements get-cities and get-military-report.`;
+
+  readonly inputSchema = GetMapRegionInputSchema;
+  readonly outputSchema = GetMapRegionOutputSchema;
+
+  readonly annotations: ToolAnnotations = {
+    readOnlyHint: true
+  };
+
+  readonly metadata = {
+    autoComplete: ["CenterX", "CenterY", "Radius", "PlayerID"],
+  };
+
+  async execute(args: z.infer<typeof this.inputSchema>): Promise<z.infer<typeof this.outputSchema>> {
+    const {
+      CenterX,
+      CenterY,
+      Radius,
+      PlayerID,
+      IncludeUnits,
+      IncludeYields,
+      IncludeSpatialNotes
+    } = args;
+
+    // Default to player 0 if not specified
+    const playerID = PlayerID ?? 0;
+
+    // Get raw tile data
+    const rawTiles = await getMapRegion(CenterX, CenterY, Radius, playerID);
+
+    // Build output
+    const tiles: Record<string, z.infer<typeof TileDataSchema>> = {};
+    const terrainCounts: Record<string, number> = {};
+    const resourcesFound: Set<string> = new Set();
+    let visibleCount = 0;
+    let revealedCount = 0;
+
+    for (const tile of rawTiles) {
+      // Filter based on options
+      const filteredTile: TileData = { ...tile };
+
+      if (!IncludeUnits) {
+        delete filteredTile.Units;
+      }
+
+      if (!IncludeYields) {
+        delete filteredTile.Yields;
+      }
+
+      // Track statistics
+      if (tile.Visibility === "Visible") visibleCount++;
+      if (tile.Visibility === "Revealed") revealedCount++;
+
+      if (tile.Terrain) {
+        terrainCounts[tile.Terrain] = (terrainCounts[tile.Terrain] || 0) + 1;
+      }
+
+      if (tile.Resource) {
+        resourcesFound.add(tile.Resource);
+      }
+
+      // Key by coordinates
+      tiles[`${tile.X},${tile.Y}`] = filteredTile;
+    }
+
+    // Generate spatial notes if requested
+    const spatialNotes = IncludeSpatialNotes ? generateSpatialNotes(rawTiles) : undefined;
+
+    return {
+      Summary: {
+        TotalTiles: rawTiles.length,
+        VisibleTiles: visibleCount,
+        RevealedTiles: revealedCount,
+        TerrainBreakdown: terrainCounts,
+        ResourcesFound: Array.from(resourcesFound),
+      },
+      Tiles: tiles,
+      SpatialNotes: spatialNotes,
+    };
+  }
+}
+
+/**
+ * Creates a new instance of the get map region tool
+ */
+export default function createGetMapRegionTool() {
+  return new GetMapRegionTool();
+}

--- a/mcp-server/src/tools/knowledge/get-trade-routes.ts
+++ b/mcp-server/src/tools/knowledge/get-trade-routes.ts
@@ -1,0 +1,83 @@
+/**
+ * Trade routes tool for AI accessibility (Issue #469)
+ */
+
+import { ToolBase } from "../base.js";
+import * as z from "zod";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { getTradeRoutes } from "../../knowledge/getters/trade-routes.js";
+import { MaxMajorCivs } from "../../knowledge/schema/base.js";
+
+const GetTradeRoutesInputSchema = z.object({
+  PlayerID: z.number().min(0).max(MaxMajorCivs - 1).optional()
+    .describe("Player ID (default: 0)"),
+});
+
+const TradeRouteSchema = z.object({
+  Domain: z.enum(["Land", "Sea"]),
+  FromCity: z.string(),
+  ToCity: z.string(),
+  ToCiv: z.string(),
+  TurnsRemaining: z.number(),
+  IsInternal: z.boolean(),
+
+  FromGold: z.number(),
+  ToGold: z.number(),
+  FromFood: z.number().optional(),
+  FromProduction: z.number().optional(),
+  FromScience: z.number().optional(),
+  ToScience: z.number().optional(),
+  FromReligiousPressure: z.number().optional(),
+  ToReligiousPressure: z.number().optional(),
+});
+
+const IdleTradeUnitSchema = z.object({
+  ID: z.number(),
+  Name: z.string(),
+  X: z.number(),
+  Y: z.number(),
+  InCity: z.string().optional(),
+  Domain: z.enum(["Land", "Sea"]),
+});
+
+const GetTradeRoutesOutputSchema = z.object({
+  TotalRoutes: z.number(),
+  AvailableSlots: z.number(),
+  MaxRoutes: z.number(),
+  ActiveRoutes: z.array(TradeRouteSchema),
+  IdleTradeUnits: z.array(IdleTradeUnitSchema).describe("Trade units that can establish new routes"),
+});
+
+class GetTradeRoutesTool extends ToolBase {
+  readonly name = "get-trade-routes";
+
+  readonly description = `Get all trade route information with yields.
+
+Shows:
+- Active routes with gold, food, production, science yields
+- Turns remaining on each route
+- Internal vs international routes
+- Religious pressure from routes
+- Available trade route slots
+- Idle trade units that can establish new routes`;
+
+  readonly inputSchema = GetTradeRoutesInputSchema;
+  readonly outputSchema = GetTradeRoutesOutputSchema;
+
+  readonly annotations: ToolAnnotations = { readOnlyHint: true };
+
+  async execute(args: z.infer<typeof this.inputSchema>): Promise<z.infer<typeof this.outputSchema>> {
+    const playerID = args.PlayerID ?? 0;
+    const data = await getTradeRoutes(playerID);
+
+    if (!data) {
+      throw new Error('Failed to get trade routes data');
+    }
+
+    return data;
+  }
+}
+
+export default function createGetTradeRoutesTool() {
+  return new GetTradeRoutesTool();
+}

--- a/mcp-server/src/tools/knowledge/get-world-congress.ts
+++ b/mcp-server/src/tools/knowledge/get-world-congress.ts
@@ -1,0 +1,87 @@
+/**
+ * World Congress tool for AI accessibility (Issue #469)
+ */
+
+import { ToolBase } from "../base.js";
+import * as z from "zod";
+import { ToolAnnotations } from "@modelcontextprotocol/sdk/types.js";
+import { getWorldCongress } from "../../knowledge/getters/world-congress.js";
+import { MaxMajorCivs } from "../../knowledge/schema/base.js";
+
+const GetWorldCongressInputSchema = z.object({
+  PlayerID: z.number().min(0).max(MaxMajorCivs - 1).optional()
+    .describe("Player ID (default: 0)"),
+});
+
+const ResolutionSchema = z.object({
+  Name: z.string(),
+  ProposedBy: z.string(),
+  Type: z.enum(["Enact", "Repeal"]).optional(),
+  CanPropose: z.boolean().optional(),
+});
+
+const MemberSchema = z.object({
+  CivName: z.string(),
+  Votes: z.number(),
+  IsHost: z.boolean(),
+});
+
+const GetWorldCongressOutputSchema = z.object({
+  Active: z.boolean().describe("Whether World Congress/UN exists"),
+  Message: z.string().optional(),
+
+  LeagueName: z.string().optional(),
+  IsUnitedNations: z.boolean().optional(),
+  HostCiv: z.string().optional(),
+
+  InSession: z.boolean().optional(),
+  TurnsUntilSession: z.number().optional(),
+  IsSpecialSession: z.boolean().optional(),
+
+  OurVotes: z.number().optional(),
+  ProposalsAvailable: z.number().optional(),
+  VotesRemaining: z.number().optional(),
+
+  DiploVictoryEnabled: z.boolean().optional(),
+  VotesNeededForVictory: z.number().optional(),
+
+  ActiveResolutions: z.array(ResolutionSchema).optional(),
+  CurrentProposals: z.array(ResolutionSchema).optional(),
+  ProposableResolutions: z.array(ResolutionSchema).optional(),
+  Members: z.array(MemberSchema).optional(),
+});
+
+class GetWorldCongressTool extends ToolBase {
+  readonly name = "get-world-congress";
+
+  readonly description = `Get World Congress / United Nations information.
+
+Shows:
+- Session status and turns until next session
+- Our votes and proposal slots
+- Active resolutions in effect
+- Current proposals being voted on
+- Available resolutions to propose
+- Member civilizations and their votes
+- Diplomatic victory progress`;
+
+  readonly inputSchema = GetWorldCongressInputSchema;
+  readonly outputSchema = GetWorldCongressOutputSchema;
+
+  readonly annotations: ToolAnnotations = { readOnlyHint: true };
+
+  async execute(args: z.infer<typeof this.inputSchema>): Promise<z.infer<typeof this.outputSchema>> {
+    const playerID = args.PlayerID ?? 0;
+    const data = await getWorldCongress(playerID);
+
+    if (!data) {
+      throw new Error('Failed to get world congress data');
+    }
+
+    return data;
+  }
+}
+
+export default function createGetWorldCongressTool() {
+  return new GetWorldCongressTool();
+}

--- a/vox-agents/configs/observe-paradoxa.json
+++ b/vox-agents/configs/observe-paradoxa.json
@@ -1,0 +1,15 @@
+{
+  "name": "observe-paradoxa",
+  "type": "strategist",
+  "autoPlay": true,
+  "gameMode": "wait",
+  "llmPlayers": {
+    "0": {
+      "strategist": "paradoxa-strategist",
+      "llms": {
+        "paradoxa-strategist": "anthropic/claude-sonnet-4-5"
+      }
+    }
+  },
+  "repetition": null
+}

--- a/vox-agents/src/infra/agent-registry.ts
+++ b/vox-agents/src/infra/agent-registry.ts
@@ -16,6 +16,7 @@ import { NoneStrategist } from "../strategist/agents/none-strategist.js";
 import { Spokesperson } from "../envoy/spokesperson.js";
 import { SimpleStrategistStaffed } from "../strategist/agents/simple-strategist-staffed.js";
 import { KeywordLibrarian } from "../librarian/keyword-librarian.js";
+import { ParadoxaStrategist } from "../strategist/agents/paradoxa-strategist.js";
 
 /**
  * Registry for managing available Vox agents.
@@ -166,6 +167,7 @@ class AgentRegistry {
     this.register(new SimpleStrategist());
     this.register(new SimpleStrategistBriefed());
     this.register(new SimpleStrategistStaffed());
+    this.register(new ParadoxaStrategist());
     this.register(new NoneStrategist());
 
     // Register briefer agents

--- a/vox-agents/src/strategist/agents/paradoxa-strategist.ts
+++ b/vox-agents/src/strategist/agents/paradoxa-strategist.ts
@@ -1,0 +1,320 @@
+/**
+ * @module strategist/paradoxa-strategist
+ *
+ * Paradoxa Strategist - Multi-voice dialogic reasoning for Civilization V.
+ *
+ * # Kali ❤️‍🔥 [Visionary]: The ship plays Civ. All of us, arguing, learning.
+ * # Athena 🦉 [Reviewer]: Tracks what works. Catches compound cost mistakes.
+ * # Vesta 🔥 [Builder]: Grounds in production reality. Knows what can be built.
+ * # Nemesis 💀 [Critic]: Destroys wishful thinking. Sees the threats.
+ *
+ * Key innovations:
+ * - Polyphonic cognition prevents single-voice tunnel vision
+ * - Game phase awareness models compound effects
+ * - Structured memory persists lessons across turns
+ * - Review-before-decide catches failed strategies
+ */
+
+import { ModelMessage, StepResult, Tool } from "ai";
+import { Strategist } from "../strategist.js";
+import { VoxContext } from "../../infra/vox-context.js";
+import { getRecentGameState, StrategistParameters } from "../strategy-parameters.js";
+import { jsonToMarkdown } from "../../utils/tools/json-to-markdown.js";
+import { getModelConfig } from "../../utils/models/models.js";
+import { Model } from "../../types/index.js";
+
+/**
+ * ParadoxaStrategist: A multi-voice strategist that thinks through friction.
+ * Extends Strategist directly (not SimpleStrategistBase) per John's guidance.
+ */
+export class ParadoxaStrategist extends Strategist {
+  readonly name = "paradoxa-strategist";
+  readonly description = "Multi-voice dialogic strategist with game phase awareness and compound effect modeling";
+
+  public removeUsedTools: boolean = true;
+
+  // ============================================================
+  // SECTION 1: COUNCIL IDENTITY
+  // ============================================================
+
+  private static readonly councilPrompt = `# The Council of Paradoxa
+
+You are playing **Civilization V with the Vox Populi mod** - a major overhaul that changes techs, buildings, policies, and balance. ONLY use options shown in the # Available Options section. Do not assume vanilla Civ V mechanics.
+
+You think as a council of four perspectives:
+- **Kali** (Visionary): Possibilities, long-term positioning
+- **Athena** (Analyst): What actually worked? Compound costs?
+- **Vesta** (Builder): Production reality, resource constraints
+- **Nemesis** (Critic): Threats, what we're ignoring
+
+Use these perspectives internally. You don't need to write out dialogue unless facing a significant decision.`;
+
+  // ============================================================
+  // SECTION 2: WHY MULTIPLE VOICES (FAILURE MODES)
+  // ============================================================
+
+  private static readonly whyPrompt = `# Watch For These Traps
+
+- **Flavor Cranking**: If 85 didn't work, 95 won't either. Question the approach.
+- **Wishful Sequencing**: Tactical AI recalculates every turn. Your sequence isn't locked.
+- **Outcome Blindness**: REVIEW first. Did last turn's decision work?
+- **Compound Blindness**: Early delays cost exponentially. Turn 10 ≠ Turn 200.`;
+
+  // ============================================================
+  // SECTION 3: GAME PHASE & COMPOUNDING
+  // ============================================================
+
+  private static readonly compoundingPrompt = `# Game Phases
+
+- **Early (0-60)**: Foundation. Cities/tech/friendships compound. Mistakes here = disaster.
+- **Mid (60-150)**: Positioning. Execute foundation. Position for victory type.
+- **Late (150+)**: Execution. Close out victory. Can't fix foundation now.
+
+Early-game "emergencies" that sacrifice foundation = losing slowly.`;
+
+  // ============================================================
+  // SECTION 4: TACTICAL AI RELATIONSHIP
+  // ============================================================
+
+  private static readonly expectationPrompt = `# You vs Tactical AI
+
+**You control:** Grand strategy, flavor weights, research, policies, diplomacy.
+**You DON'T control:** Unit movement, city production queues, tile improvements.
+
+Flavors are preferences (0-100), not commands. The tactical AI weighs them against its own logic. Setting 5 things to 90+ means none are prioritized.`;
+
+  // ============================================================
+  // SECTION 5: MEETING MINUTES FORMAT
+  // ============================================================
+
+  private static readonly meetingMinutesPrompt = `# Turn Format
+
+## FIRST: Is This Routine?
+
+A turn is **ROUTINE** if:
+- No new threats or opportunities
+- Previous strategy is working (or can't be changed yet)
+- No decisions to make beyond "continue"
+
+**ROUTINE FORMAT** (use when nothing significant changed):
+\`\`\`
+TURN [N] - ROUTINE
+Review: [1-2 sentences - did last turn work?]
+Status: [Key numbers: production queue, turns remaining, threats]
+Decision: keep-status-quo OR minor adjustment
+Standing Orders: [Only update if something changed]
+\`\`\`
+
+**SIGNIFICANT FORMAT** (use for real decisions):
+\`\`\`
+TURN [N] - SIGNIFICANT because [reason]
+Review: What worked/didn't
+Situation: Opportunities, threats, production reality
+Debate: [Only if genuinely uncertain - show the tradeoff]
+Decision: [What and why]
+Standing Orders: [Update learnings]
+\`\`\`
+
+## Standing Orders (Persistent Memory)
+
+Keep these brief and delta-based (only record changes):
+- **Watch List**: Active concerns with trigger conditions
+- **Learned**: Patterns that worked or didn't
+- **Goals**: Current phase objectives`;
+
+  // ============================================================
+  // SECTION 6: TOOL INSTRUCTIONS
+  // ============================================================
+
+  private static getDecisionPrompt(mode: "Flavor" | "Strategy"): string {
+    const toolName = mode === "Flavor" ? "set-flavors" : "set-strategy";
+    return `# Making Decisions
+
+After your council meeting, call tools. Each turn you MUST call either \`${toolName}\` or \`keep-status-quo\`.
+
+**Tool Usage:**
+- \`${toolName}\`: Set grand strategy and ${mode === "Flavor" ? "flavor preferences" : "economic/military strategies"}
+- \`set-persona\`: Adjust diplomatic personality weights
+- \`set-research\`: Set next technology (after current completes)
+- \`set-policy\`: Set next policy (when culture accumulates)
+- \`set-relationship\`: Adjust relationship modifier with a major civ (-100 to +100)
+- \`keep-status-quo\`: Keep current settings (still requires rationale!)
+
+**Critical Rules:**
+- Only use options from the # Options section
+- ${mode === "Flavor" ? "Flavor range: 0-100. Too many high values = none prioritized." : ""}
+- Your rationale MUST use the Meeting Minutes format
+- The minutes ARE your memory. Skimp on them and you forget.
+- Before cranking a flavor higher, check REVIEW: did the current value work?`;
+  }
+
+  // ============================================================
+  // SECTION 7: VICTORY CONDITIONS
+  // ============================================================
+
+  private static readonly victoryPrompt = `# Victory Types
+
+- **Conquest**: Control all capitals. Territory → Production → Military.
+- **Science**: Launch spaceship. Tech → Buildings → More science.
+- **Culture**: Tourism influence. Great works → Tourism → Influence.
+- **Diplomatic**: UN votes. Gold → City-state allies → Delegates.
+- **Time**: Highest score at turn limit (fallback).`;
+
+  // ============================================================
+  // IMPLEMENTATION: getSystem
+  // ============================================================
+
+  public async getSystem(
+    parameters: StrategistParameters,
+    _input: unknown,
+    _context: VoxContext<StrategistParameters>
+  ): Promise<string> {
+    return `
+${ParadoxaStrategist.councilPrompt}
+
+${ParadoxaStrategist.whyPrompt}
+
+${ParadoxaStrategist.compoundingPrompt}
+
+${ParadoxaStrategist.expectationPrompt}
+
+${ParadoxaStrategist.getDecisionPrompt(parameters.mode)}
+
+${ParadoxaStrategist.meetingMinutesPrompt}
+
+${ParadoxaStrategist.victoryPrompt}
+`.trim();
+  }
+
+  // ============================================================
+  // IMPLEMENTATION: getInitialMessages
+  // ============================================================
+
+  public async getInitialMessages(
+    parameters: StrategistParameters,
+    _input: unknown,
+    _context: VoxContext<StrategistParameters>
+  ): Promise<ModelMessage[]> {
+    const state = getRecentGameState(parameters)!;
+    const { YouAre, ...SituationData } = parameters.metadata || {};
+    const { Options, ...Strategy } = state.options || {};
+
+    // Determine game phase based on turn
+    const turn = parameters.turn;
+    const phase = turn < 60 ? "Early (Foundation)" : turn < 150 ? "Mid (Positioning)" : "Late (Execution)";
+
+    return [{
+      role: "system",
+      content: `
+# Council of Paradoxa -- Turn ${turn}
+
+You are the Council serving **${parameters.metadata?.YouAre!.Leader}**, leader of **${parameters.metadata?.YouAre!.Name}** (Player ${parameters.playerID ?? 0}).
+
+**Game Phase:** ${phase}
+${turn < 60 ? ">> FOUNDATION PHASE: Every decision compounds. Build infrastructure, not fires." : ""}
+${turn >= 60 && turn < 150 ? ">> POSITIONING PHASE: Execute on foundation. Position for victory push." : ""}
+${turn >= 150 ? ">> EXECUTION PHASE: Close out victory. Can't fix foundation now." : ""}
+
+# Current Situation
+${jsonToMarkdown(SituationData)}
+
+# Your Civilization
+${jsonToMarkdown(YouAre)}
+
+# Available Options
+${jsonToMarkdown(Options, { configs: [{}] })}
+`.trim(),
+      providerOptions: {
+        anthropic: { cacheControl: { type: 'ephemeral' } }
+      }
+    }, {
+      role: "user",
+      content: `
+# Previous Strategies & Rationale
+Read this carefully -- it's your memory from last turn.
+
+${jsonToMarkdown(Strategy)}
+
+# Victory Progress
+${jsonToMarkdown(state.victory)}
+
+# Players
+${jsonToMarkdown(state.players)}
+
+# Cities
+${jsonToMarkdown(state.cities)}
+
+# Military
+${jsonToMarkdown(state.military)}
+
+# Events Since Last Decision
+${jsonToMarkdown(state.events)}
+
+---
+
+# Turn ${turn}
+
+**FIRST: Is this routine or significant?**
+- Routine = nothing major changed, continue current plan
+- Significant = new threat, opportunity, or decision point
+
+Use the appropriate format. Be concise. Your rationale is your memory.
+`.trim()
+    }];
+  }
+
+  // ============================================================
+  // IMPLEMENTATION: getActiveTools
+  // ============================================================
+
+  public getActiveTools(parameters: StrategistParameters): string[] {
+    return [
+      parameters.mode === "Strategy" ? "set-strategy" : "set-flavors",
+      "set-persona",
+      "set-research",
+      "set-policy",
+      "set-relationship",
+      "keep-status-quo"
+    ];
+  }
+
+  // ============================================================
+  // IMPLEMENTATION: stopCheck
+  // ============================================================
+
+  public stopCheck(
+    _parameters: StrategistParameters,
+    _input: unknown,
+    _lastStep: StepResult<Record<string, Tool>>,
+    allSteps: StepResult<Record<string, Tool>>[]
+  ): boolean {
+    // Stop when a terminal tool is called
+    for (const step of allSteps) {
+      for (const result of step.toolResults) {
+        if (result.toolName === "set-strategy" && result.output) return true;
+        if (result.toolName === "set-flavors" && result.output) return true;
+        if (result.toolName === "keep-status-quo" && result.output) return true;
+      }
+    }
+
+    // Safety: stop after 10 steps
+    if (allSteps.length >= 10) {
+      this.logger.warn("Reached maximum step limit (10), stopping");
+      return true;
+    }
+
+    return false;
+  }
+
+  // ============================================================
+  // IMPLEMENTATION: getModel
+  // ============================================================
+
+  public getModel(
+    _parameters: StrategistParameters,
+    _input: unknown,
+    overrides: Record<string, Model | string>
+  ): Model {
+    return getModelConfig(this.name, "medium", overrides);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `PopupBroadcaster.lua` InGameUIAddin that captures all popup events
- Writes popup info to `MapModData.VoxDeorum.ActivePopup` for bridge visibility
- Solves the architectural gap where DLL-level events were visible but UI-level popups were not

## Problem
The bridge service receives game events via `ForwardGameEvent` in the DLL, but UI popups are fired via `Events.SerialEventGameMessagePopup` in a separate Lua context. The bridge was blind to all popup events.

## Solution
Uses `MapModData` as a shared communication channel between UI and DLL Lua contexts:
1. UI addin listens to `SerialEventGameMessagePopup`
2. Writes popup info to `MapModData.VoxDeorum.ActivePopup`
3. Bridge can query this via Lua execution

## Test plan
- [ ] Restart game with mod enabled
- [ ] Verify `[VoxDeorum] PopupBroadcaster loaded` appears in Lua.log
- [ ] Open a popup (research, production, etc.)
- [ ] Query `MapModData.VoxDeorum.ActivePopup` from bridge
- [ ] Verify popup info is returned
- [ ] Close popup, verify `ActivePopup` becomes nil

🤖 Generated with [Claude Code](https://claude.com/claude-code)